### PR TITLE
Add always-rethrow-or-return rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ Ensures that any catching of errors will rethrow or handle (opting out is the ex
 
 ### Valid
 ```js
-myPromise.catch(functio() { return val; })
-myPromise.catch(functio(err) { throw err; })
-myPromise.then(null, functio() { return val; })
-myPromise.tehn(null, functio(err) { throw err; })
+myPromise.catch(function() { return val; })
+myPromise.catch(function(err) { throw err; })
+myPromise.then(null, function() { return val; })
+myPromise.tehn(null, function(err) { throw err; })
 ```
 
 ### Invalid
 ```js
-myPromise.then(null, functio() { doWorkButDontRethrowOrReturn(); })
-myPromise.catch(functio() { doWorkButDontRethrowOrReturn(); })
+myPromise.then(null, function() { doWorkButDontRethrowOrReturn(); })
+myPromise.catch(function() { doWorkButDontRethrowOrReturn(); })
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ new Promise(function (ok, fail) { ... }) // non-standard parameter names
 
 Ensures that `new Promise()` is instantiated with the parameter names `resolve, reject` to avoid confusion with order such as `reject, resolve`. The Promise constructor uses the [RevealingConstructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/). Using the same parameter names as the language specification makes code more uniform and easier to understand.
 
+### `always-rethrow-or-return`
+
+Ensures that any catching of errors will rethrow or handle (opting out is the exception).
+
+### Valid
+```js
+myPromise.catch(functio() { return val; })
+myPromise.catch(functio(err) { throw err; })
+myPromise.then(null, functio() { return val; })
+myPromise.tehn(null, functio(err) { throw err; })
+```
+
+### Invalid
+```js
+myPromise.then(null, functio() { doWorkButDontRethrowOrReturn(); })
+myPromise.catch(functio() { doWorkButDontRethrowOrReturn(); })
+```
+
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ module.exports = {
     'param-names': require('./rules/param-names'),
     'always-return': require('./rules/always-return'),
     'always-catch': require('./rules/always-catch'),
-    'catch-or-return': require('./rules/catch-or-return')
+    'catch-or-return': require('./rules/catch-or-return'),
+    'always-rethrow-or-return': require('./rules/always-rethrow-or-return')
   },
   rulesConfig: {
     'param-names': 1,
     'always-return': 1,
     'always-catch': 1,
-    'catch-or-return': 1
+    'catch-or-return': 1,
+    'always-rethrow-or-return': 1
   }
 }

--- a/rules/always-rethrow-or-return.js
+++ b/rules/always-rethrow-or-return.js
@@ -1,0 +1,55 @@
+module.exports = function (context) {
+  return {
+    CallExpression: function (node) {
+      var func
+
+      if (node.callee.type !== 'MemberExpression') {
+        return
+      }
+
+      if (node.callee.property && node.callee.property.name === 'then') {
+        func = node.arguments[1]
+      } else if (node.callee.property && node.callee.property.name === 'catch') {
+        func = node.arguments[0]
+      }
+
+      if (!func) {
+        return
+      }
+
+      var body
+      if (func.type === 'FunctionExpression') {
+        body = func.body.body
+      } else if (func.type === 'ArrowFunctionExpression') {
+        if (func.body.type === 'BlockStatement') {
+          body = func.body.body
+        } else {
+          // We're returning via short-hand arrow syntax
+          // () => returnValue
+          return
+        }
+      } else {
+        // We aren't dealing with a function expression so can't
+        // do too much here :(
+        return
+      }
+
+      var foundReturnOrThrow
+      var bodyLen = body.length
+      for (var i = 0; i < bodyLen; ++i) {
+        var funcNode = body[i]
+        if (
+          funcNode.type === 'ThrowStatement' ||
+          funcNode.type === 'ReturnStatement'
+        ) {
+          foundReturnOrThrow = funcNode
+          break
+        }
+      }
+
+      if (!foundReturnOrThrow) {
+        context.report(func, 'Should rethrow errors or handle by returning some value when catching within a Promise!')
+      }
+    }
+  }
+}

--- a/test/always-rethrow-or-return.test.js
+++ b/test/always-rethrow-or-return.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+var rule = require('../rules/always-rethrow-or-return')
+var RuleTester = require('eslint').RuleTester
+
+var ecmaFeatures = { arrowFunctions: true }
+
+var ruleTester = new RuleTester()
+ruleTester.run('always-rethrow-or-return', rule, {
+
+  valid: [
+    'promise.catch(function() { return next(); })',
+    'promise.catch(function(err) { throw err; })',
+    'promise.then(function() {}, function() { return next(); })',
+    'promise.then(function() {}, function(err) { throw err; })',
+    'promise.then(function() {}, randomIdentifier)',
+    'promise.catch(randomIdentifier)',
+    {code: 'promise.then(() => {}, err => err)', ecmaFeatures: ecmaFeatures},
+    {code: 'promise.catch(err => err)', ecmaFeatures: ecmaFeatures},
+    {code: 'promise.catch(() => { return next(); })', ecmaFeatures: ecmaFeatures},
+    {code: 'promise.catch((err) => { throw err; })', ecmaFeatures: ecmaFeatures},
+    {code: 'promise.then(() => {}, () => { return next(); })', ecmaFeatures: ecmaFeatures},
+    {code: 'promise.then(() => {}, (err) => { throw err; })', ecmaFeatures: ecmaFeatures}
+  ],
+
+  invalid: [
+    {
+      code: 'promise.catch(function() { doWorkButDontRethrow(); })',
+      errors: [{
+        message: 'Should rethrow errors or handle by returning some value when catching within a Promise!',
+        type: 'FunctionExpression'
+      }]
+    },
+    {
+      code: 'promise.then(function() {}, function() { doWorkButDontRethrow(); })',
+      errors: [{
+        message: 'Should rethrow errors or handle by returning some value when catching within a Promise!',
+        type: 'FunctionExpression'
+      }]
+    },
+    {
+      code: 'promise.catch(() => { doWorkButDontRethrow(); })',
+      ecmaFeatures: ecmaFeatures,
+      errors: [{
+        message: 'Should rethrow errors or handle by returning some value when catching within a Promise!',
+        type: 'ArrowFunctionExpression'
+      }]
+    },
+    {
+      code: 'promise.then(() => {}, () => { doWorkButDontRethrow(); })',
+      ecmaFeatures: ecmaFeatures,
+      errors: [{
+        message: 'Should rethrow errors or handle by returning some value when catching within a Promise!',
+        type: 'ArrowFunctionExpression'
+      }]
+    }
+  ]
+})


### PR DESCRIPTION
Adds a lint rule when promise rejections are caught but not rethrown or explicitly handled via a return statement.

Addresses: https://github.com/xjamundx/eslint-plugin-promise/issues/7

Explore on ASTExplorer: https://astexplorer.net/#/Nzw2dhjse2/3