### PR TITLE
Make no-native work with ???

### DIFF
--- a/rules/no-native.js
+++ b/rules/no-native.js
@@ -31,7 +31,7 @@ module.exports = function (context) {
     'Program:exit': function () {
       var scope = context.getScope()
 
-      scope.through.forEach(function (ref) {
+      scope.implicit.left.forEach(function (ref) {
         if (ref.identifier.name !== 'Promise') {
           return
         }


### PR DESCRIPTION
Sorry to be a pain, but I've found that the no-native part of this plugin does not pick up native promises in our project and I'm not 100% why.

At first I thought it might be because we're using the current version of eslint, when I saw this: https://github.com/eslint/eslint/pull/4648/files, but I've run the tests in this plugin against eslint 2 and while a bunch of them fail, the no-native ones pass. We use a huge mess of packages so trying to work out where the bad interaction/transpilation happens is a difficult task.

I've played around with the various lists of references on a scope and found that `scope.implicit.left` appears to include the native uses of `Promise` in my project, and in this plugin's tests, so I think we're going to run off this fork for now.

I thought maybe you have a better understanding of eslint internals and might be able to suggest what could cause some references to `Promise` to not appear in the the `.through` reference list, or if changing it to `.implict.left` is a bad idea