### PR TITLE
Add option for multiple terminationMethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ You can pass an `{ allowThen: true }` as an option to this rule
 You can pass a `{ terminationMethod: 'done' }` as an option to this rule
  to require `done()` instead of `catch()` at the end of the promise chain.
  This is useful for many non-standard Promise implementations.
+ 
+You can also pass an array of methods such as
+ `{ terminationMethod: ['catch',  'asCallback'] }`
 
 ### `always-return`
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ You can pass a `{ terminationMethod: 'done' }` as an option to this rule
  This is useful for many non-standard Promise implementations.
  
 You can also pass an array of methods such as
- `{ terminationMethod: ['catch',  'asCallback'] }`
+ `{ terminationMethod: ['catch',  'asCallback', 'finally'] }`.
+ 
+ This will allow any of
+```js
+Promise.resolve(1).then(() => { throw new Error('oops') }).catch(logerror)
+Promise.resolve(1).then(() => { throw new Error('oops') }).asCallback(cb)
+Promise.resolve(1).then(() => { throw new Error('oops') }).finally(cleanUp)
+```
 
 ### `always-return`
 

--- a/rules/catch-or-return.js
+++ b/rules/catch-or-return.js
@@ -33,6 +33,10 @@ module.exports = {
     var allowThen = options.allowThen
     var terminationMethod = options.terminationMethod || 'catch'
 
+    if (typeof terminationMethod === 'string') {
+      terminationMethod = [terminationMethod]
+    }
+
     return {
       ExpressionStatement: function (node) {
         if (!isPromise(node.expression)) {
@@ -52,7 +56,7 @@ module.exports = {
         // somePromise.catch()
         if (node.expression.type === 'CallExpression' &&
           node.expression.callee.type === 'MemberExpression' &&
-          node.expression.callee.property.name === terminationMethod
+          terminationMethod.indexOf(node.expression.callee.property.name) !== -1
         ) {
           return
         }

--- a/test/catch-or-return.test.js
+++ b/test/catch-or-return.test.js
@@ -45,8 +45,11 @@ ruleTester.run('catch-or-return', rule, {
     { code: 'frank.then(go).then(to).then(pewPew, jail)', options: [{ 'allowThen': true }] },
 
     // terminationMethod=done - .done(null, fn)
-    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': 'done' }] }
+    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': 'done' }] },
 
+    // terminationMethod=[catch, done] - .done(null, fn)
+    { code: 'frank().then(go).catch()', options: [{ 'terminationMethod': ['catch', 'done'] }] },
+    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': ['catch', 'done'] }] }
   ],
 
   invalid: [

--- a/test/catch-or-return.test.js
+++ b/test/catch-or-return.test.js
@@ -49,7 +49,8 @@ ruleTester.run('catch-or-return', rule, {
 
     // terminationMethod=[catch, done] - .done(null, fn)
     { code: 'frank().then(go).catch()', options: [{ 'terminationMethod': ['catch', 'done'] }] },
-    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': ['catch', 'done'] }] }
+    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': ['catch', 'done'] }] },
+    { code: 'frank().then(go).finally()', options: [{ 'terminationMethod': ['catch', 'finally'] }] }
   ],
 
   invalid: [


### PR DESCRIPTION
An array can now be passed for the terminationMethod option.
Allows use of multiple valid terminators.

Bluebird has the `asCallback` method which is also a valid terminator in addition to `catch`.