### PR TITLE
always-return fails with ternary statements

### DIFF
--- a/test/always-return.test.js
+++ b/test/always-return.test.js
@@ -26,6 +26,7 @@ ruleTester.run('always-return', rule, {
     { code: 'hey.then(x => { return x; var y = "unreachable"; })', parserOptions: parserOptions },
     { code: 'hey.then(x => { return; }, err=>{ log(err); })', parserOptions: parserOptions },
     { code: 'hey.then(x => { return x && x(); }, err=>{ log(err); })', parserOptions: parserOptions },
+    { code: 'hey.then(x => { return a ? b : c; })', parserOptions: parserOptions },
     { code: 'hey.then(x => { return x.y || x(); }, err=>{ log(err); })', parserOptions: parserOptions }
   ],
 


### PR DESCRIPTION
This PR creates a failing test case for always-return, which fails when dealing with ternary statements.

I have no experience with code path analysis with ESLint (or rather, a bad one as I never got my around it :sweat_smile:), so I'd prefer not to fix this myself, but let me know if I can help in some way :)