### PR TITLE
Remove eslint as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "mocha": "^2.3.4",
     "standard": "^7.1.2"
   },
-  "peerDependencies": {
-    "eslint": "^2.10 || ^3.0"
-  },
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
This plugin doesn't technically depend on eslint (there are no require calls to eslint, except in test).

Listing eslint as peer dependency is problematic, when this repository is not used as direct dependency, but rather required in something like https://github.com/feross/standard

Currently installation of standard results in following warnings:

```
└─┬ standard@8.5.0
  ├─┬ UNMET PEER DEPENDENCY eslint@3.8.1
  │ ├── globals@9.12.0
  │ ├── strip-bom@3.0.0
  │ └── user-home@2.0.0
  ├── eslint-config-standard@6.2.1
  ├── eslint-config-standard-jsx@3.2.0
  ├── UNMET PEER DEPENDENCY eslint-plugin-promise@3.3.1
  ├─┬ eslint-plugin-react@6.4.1
  │ └── jsx-ast-utils@1.3.3
  ├── eslint-plugin-standard@2.0.1
  └─┬ standard-engine@5.1.1
    ├─┬ deglob@2.0.0
    │ ├── run-parallel@1.1.6
    │ └── uniq@1.0.1
    ├── find-root@1.0.0
    ├── get-stdin@5.0.1
    └─┬ pkg-config@1.1.1
      └── debug-log@1.0.1
```

This PR fixes this issue. Non of the other eslint plugins lists eslint as peerDependency.