### PR TITLE
Replaced 'loc' with 'node' for context.report

### DIFF
--- a/rules/always-return.js
+++ b/rules/always-return.js
@@ -85,7 +85,7 @@ module.exports = {
       onCodePathSegmentStart: function (segment, node) {
         var funcInfo = peek(funcInfoStack)
         funcInfo.branchIDStack.push(segment.id)
-        funcInfo.branchInfoMap[segment.id] = {good: false, loc: node.loc}
+        funcInfo.branchInfoMap[segment.id] = {good: false, node: node}
       },
 
       onCodePathSegmentEnd: function (segment, node) {
@@ -120,7 +120,7 @@ module.exports = {
 
             context.report({
               message: 'Each then() should return a value or throw',
-              loc: branch.loc
+              node: branch.node
             })
           }
         })


### PR DESCRIPTION
Should fix the reported location for *promise/always-return* errors.
Tested with both `eslint@^2` and `eslint@^3`, but I don't know how to add it to project tests :/
