### PR TITLE
option: add allowReject for no-return-wrap (fixes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ myPromise.then(function(val) {
 })
 ```
 
+#### Options
+
+#### `allowReject`
+
+Pass `{ allowReject: true }` as an option to this rule to permit wrapping returned values with `Promise.reject`, such as when you would use it as another way to reject the promise.
+
 ## Etc
+
 - (c) MMXV jden <jason@denizac.org> - ISC license.
 - (c) 2016 Jamund Ferguson <jamund@gmail.com> - ISC license.

--- a/rules/no-return-wrap.js
+++ b/rules/no-return-wrap.js
@@ -19,6 +19,9 @@ function isInPromise (context) {
 
 module.exports = {
   create: function (context) {
+    var options = context.options[0] || {}
+    var allowReject = options.allowReject
+
     return {
       ReturnStatement: function (node) {
         if (isInPromise(context)) {
@@ -28,7 +31,7 @@ module.exports = {
                 if (node.argument.callee.object.name === 'Promise') {
                   if (node.argument.callee.property.name === 'resolve') {
                     context.report(node, resolveMessage)
-                  } else if (node.argument.callee.property.name === 'reject') {
+                  } else if (!allowReject && node.argument.callee.property.name === 'reject') {
                     context.report(node, rejectMessage)
                   }
                 }

--- a/test/no-return-wrap.js
+++ b/test/no-return-wrap.js
@@ -43,7 +43,10 @@ ruleTester.run('no-return-wrap', rule, {
     'doThing(function(x) { return Promise.reject(x) })',
 
     // should work with empty return statement
-    'doThing().then(function() { return })'
+    'doThing().then(function() { return })',
+
+    // allow reject if specified
+    {code: 'doThing().then(function() { return Promise.reject(4) })', options: [{allowReject: true}]}
   ],
 
   invalid: [


### PR DESCRIPTION
Adds option to the no-return-wrap rule that was proposed in #50.

Example:

**Invalid**

```javascript
/*eslint promise/no-return-wrap: "error"*/
myPromise.then(() => {
  return Promise.reject(new Error("bad thing"))
});
myPromise.then(function() { return Promise.reject(42) });
```

**Valid**

```javascript
/*eslint promise/no-return-wrap: ["error", { allowReject: true }]*/
myPromise.then(() => {
  return Promise.reject(new Error("bad thing"))
});
myPromise.then(function() { return Promise.reject(42) });
```