### PR TITLE
rule: no-return-in-finally (fixes #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Then configure the rules you want to use under the rules section.
         "promise/no-nesting": "warn",
         "promise/no-promise-in-callback": "warn",
         "promise/no-callback-in-promise": "warn",
-        "promise/avoid-new": "warn"
+        "promise/avoid-new": "warn",
+        "promise/no-return-in-finally": "warn"
     }
 }
 ```
@@ -79,6 +80,7 @@ or start with the recommended rule set
 | :warning:   | `no-promise-in-callback`    | Avoid using promises inside of callbacks                                         |
 | :warning:   | `no-callback-in-promise`    | Avoid calling `cb()` inside of a `then()` (use [nodeify][] instead)             |
 | :warning:   | `avoid-new`                 | Avoid creating `new` promises outside of utility libs (use [pify][] instead)     |
+| :warning:   | `no-return-in-finally`      | Disallow return statements in `finally()`                                        |
 | :seven:     | `prefer-await-to-then`      | Prefer `await` to `then()` for reading Promise values                            |
 | :seven:     | `prefer-await-to-callbacks` | Prefer async/await to the callback pattern                                       |
 
@@ -223,6 +225,24 @@ myPromise.then(function(val) {
 });
 myPromise.then(function(val) {
   return Promise.reject("bad thing");
+})
+```
+
+### Rule: `no-return-in-finally`
+
+Disallow return statements inside a callback passed to `finally()`, since nothing would consume what's returned.
+
+#### Valid
+```js
+myPromise.finally(function(val) {
+  console.log('value:', val);
+});
+```
+
+#### Invalid
+```js
+myPromise.finally(function(val) {
+  return val;
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = {
     'no-callback-in-promise': require('./rules/no-callback-in-promise'),
     'no-promise-in-callback': require('./rules/no-promise-in-callback'),
     'no-nesting': require('./rules/no-nesting'),
-    'avoid-new': require('./rules/avoid-new')
+    'avoid-new': require('./rules/avoid-new'),
+    'no-return-in-finally': require('./rules/no-return-in-finally')
   },
   rulesConfig: {
     'param-names': 1,
@@ -30,7 +31,8 @@ module.exports = {
         'promise/no-nesting': 'warn',
         'promise/no-promise-in-callback': 'warn',
         'promise/no-callback-in-promise': 'warn',
-        'promise/avoid-new': 'warn'
+        'promise/avoid-new': 'warn',
+        'promise/no-return-in-finally': 'warn'
       }
     }
   }

--- a/rules/lib/is-promise.js
+++ b/rules/lib/is-promise.js
@@ -18,6 +18,10 @@ function isPromise (expression) {
   expression.type === 'CallExpression' &&
   expression.callee.type === 'MemberExpression' &&
   expression.callee.property.name === 'catch'
+  ) || ( // hello.finally()
+  expression.type === 'CallExpression' &&
+  expression.callee.type === 'MemberExpression' &&
+  expression.callee.property.name === 'finally'
   ) || ( // somePromise.ANYTHING()
   expression.type === 'CallExpression' &&
   expression.callee.type === 'MemberExpression' &&

--- a/rules/no-return-in-finally.js
+++ b/rules/no-return-in-finally.js
@@ -1,0 +1,19 @@
+var isPromise = require('./lib/is-promise')
+
+module.exports = {
+  create: function (context) {
+    return {
+      CallExpression: function (node) {
+        if (isPromise(node)) {
+          if (node.callee && node.callee.property && node.callee.property.name === 'finally') {
+            if (node.arguments && node.arguments[0] && node.arguments[0].body && node.arguments[0].body.body) {
+              if (node.arguments[0].body.body.some(function (statement) { return statement.type === 'ReturnStatement' })) {
+                context.report(node.callee.property, 'No return in finally')
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/no-return-in-finally.js
+++ b/test/no-return-in-finally.js
@@ -1,0 +1,20 @@
+var RuleTester = require('eslint').RuleTester
+var rule = require('../rules/no-return-in-finally')
+var ruleTester = new RuleTester()
+var message = 'No return in finally'
+
+ruleTester.run('no-return-in-finally', rule, {
+  valid: [
+    { code: 'Promise.resolve(1).finally(() => { console.log(2) })', parserOptions: { ecmaVersion: 6 } },
+    { code: 'Promise.reject(4).finally(() => { console.log(2) })', parserOptions: { ecmaVersion: 6 } },
+    { code: 'Promise.reject(4).finally(() => {})', parserOptions: { ecmaVersion: 6 } },
+    { code: 'myPromise.finally(() => {});', parserOptions: { ecmaVersion: 6 } },
+    { code: 'Promise.resolve(1).finally(function () { })' }
+  ],
+  invalid: [
+    { code: 'Promise.resolve(1).finally(() => { return 2 })', parserOptions: { ecmaVersion: 6 }, errors: [ { message: message } ] },
+    { code: 'Promise.reject(0).finally(() => { return 2 })', parserOptions: { ecmaVersion: 6 }, errors: [ { message: message } ] },
+    { code: 'myPromise.finally(() => { return 2 });', parserOptions: { ecmaVersion: 6 }, errors: [ { message: message } ] },
+    { code: 'Promise.resolve(1).finally(function () { return 2 })', errors: [ { message: message } ] }
+  ]
+})


### PR DESCRIPTION
Adds a rule that disallows return statements it the callback passed to `.finally()`.

**Valid**

```javascript
myPromise.finally(function(val) {
  console.log('value:', val);
});
```

**Invalid**

```javascript
myPromise.finally(function(val) {
  return val;
})
```

I suggested reporting as a warning in the recommended rules since the violation likely has no ill effects.