### PR TITLE
chore(package): update to mocha v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "eslint": "^3.0",
-    "mocha": "^2.3.4",
+    "mocha": "^5.0.0",
     "standard": "^7.1.2"
   },
   "engines": {


### PR DESCRIPTION
Looking at the [Mocha changelog](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md), I'm not seeing any breaking changes that apply to this codebase.