### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
When running `npm install` in this codebase with npm v5, it defaults to generating a `package-lock.json` file. Setting `package-lock=false` will prevent generating this file when running `npm install`.

If you would like this file added to `.gitignore` instead, or would like to include this file in the repository, I would be glad to change this PR or open another one. 👍 