### PR TITLE
chore(package): update to standard v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "eslint": "^3.0",
     "mocha": "^2.3.4",
-    "standard": "^7.1.2"
+    "standard": "^10.0.3"
   },
   "engines": {
     "node": ">=4"

--- a/rules/lib/is-inside-promise.js
+++ b/rules/lib/is-inside-promise.js
@@ -1,9 +1,9 @@
 function isInsidePromise (node) {
   var isFunctionExpression = node.type === 'FunctionExpression' ||
-      node.type === 'ArrowFunctionExpression'
+    node.type === 'ArrowFunctionExpression'
   var parent = node.parent || {}
   var callee = parent.callee || {}
-  var name = callee.property && callee.property.name || ''
+  var name = (callee.property && callee.property.name) || ''
   var parentIsPromise = name === 'then' || name === 'catch'
   var isInCB = isFunctionExpression && parentIsPromise
   return isInCB

--- a/rules/prefer-await-to-callbacks.js
+++ b/rules/prefer-await-to-callbacks.js
@@ -30,7 +30,7 @@ module.exports = function (context) {
       var args = node.arguments
       var num = args.length - 1
       var arg = num > -1 && node.arguments && node.arguments[num]
-      if (arg && arg.type === 'FunctionExpression' || arg.type === 'ArrowFunctionExpression') {
+      if (arg && (arg.type === 'FunctionExpression' || arg.type === 'ArrowFunctionExpression')) {
         if (arg.params && arg.params[0] && arg.params[0].name === 'err') {
           if (!isInsideYieldOrAwait()) {
             context.report(arg, errorMessage)


### PR DESCRIPTION
This PR updates to the latest stabled version of Standard. The only change that seemed to affect this codebase was https://github.com/standard/standard/issues/816. Fixing the error is addressed in `rules/lib/is-inside-promise.js` and `rules/prefer-await-to-callbacks.js`.

[Standard changelog](https://github.com/standard/standard/blob/master/CHANGELOG.md), for reference