### PR TITLE
feat(rule): add no-new-statics rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Then configure the rules you want to use under the rules section.
     "promise/no-promise-in-callback": "warn",
     "promise/no-callback-in-promise": "warn",
     "promise/avoid-new": "warn",
+    "promise/no-new-statics": "warn",
     "promise/no-return-in-finally": "warn"
   }
 }
@@ -87,6 +88,7 @@ or start with the recommended rule set
 | [`no-promise-in-callback`][no-promise-in-callback]       | Avoid using promises inside of callbacks                                         | :warning:   |          |
 | [`no-callback-in-promise`][no-callback-in-promise]       | Avoid calling `cb()` inside of a `then()` (use [nodeify][] instead)              | :warning:   |          |
 | [`avoid-new` ][avoid-new]                                | Avoid creating `new` promises outside of utility libs (use [pify][] instead)     | :warning:   |          |
+| [`no-new-statics`][no-new-statics]                       | Avoid calling `new` on a Promise static method (e.g. `new Promise.resolve()`)    | :bangbang:  |          |
 | [`no-return-in-finally`][no-return-in-finally]           | Disallow return statements in `finally()`                                        | :warning:   |          |
 | [`prefer-await-to-then`][prefer-await-to-then]           | Prefer `await` to `then()` for reading Promise values                            | :seven:     |          |
 | [`prefer-await-to-callbacks`][prefer-await-to-callbacks] | Prefer async/await to the callback pattern                                       | :seven:     |          |
@@ -119,6 +121,7 @@ or start with the recommended rule set
 [no-promise-in-callback]: docs/rules/no-promise-in-callback.md
 [no-callback-in-promise]: docs/rules/no-callback-in-promise.md
 [avoid-new]: docs/rules/avoid-new.md
+[no-new-statics]: docs/rules/no-new-statics.md
 [no-return-in-finally]: docs/rules/no-return-in-finally.md
 [prefer-await-to-then]: docs/rules/prefer-await-to-then.md
 [prefer-await-to-callbacks]: docs/rules/prefer-await-to-callbacks.md

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Then configure the rules you want to use under the rules section.
     "promise/no-promise-in-callback": "warn",
     "promise/no-callback-in-promise": "warn",
     "promise/avoid-new": "warn",
-    "promise/no-new-statics": "warn",
+    "promise/no-new-statics": "error",
     "promise/no-return-in-finally": "warn"
   }
 }
@@ -88,7 +88,7 @@ or start with the recommended rule set
 | [`no-promise-in-callback`][no-promise-in-callback]       | Avoid using promises inside of callbacks                                         | :warning:   |          |
 | [`no-callback-in-promise`][no-callback-in-promise]       | Avoid calling `cb()` inside of a `then()` (use [nodeify][] instead)              | :warning:   |          |
 | [`avoid-new` ][avoid-new]                                | Avoid creating `new` promises outside of utility libs (use [pify][] instead)     | :warning:   |          |
-| [`no-new-statics`][no-new-statics]                       | Avoid calling `new` on a Promise static method (e.g. `new Promise.resolve()`)    | :bangbang:  |          |
+| [`no-new-statics`][no-new-statics]                       | Avoid calling `new` on a Promise static method                                   | :bangbang:  |          |
 | [`no-return-in-finally`][no-return-in-finally]           | Disallow return statements in `finally()`                                        | :warning:   |          |
 | [`prefer-await-to-then`][prefer-await-to-then]           | Prefer `await` to `then()` for reading Promise values                            | :seven:     |          |
 | [`prefer-await-to-callbacks`][prefer-await-to-callbacks] | Prefer async/await to the callback pattern                                       | :seven:     |          |

--- a/__tests__/no-new-statics.js
+++ b/__tests__/no-new-statics.js
@@ -4,8 +4,6 @@ const rule = require('../rules/no-new-statics')
 const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
-const message = 'Avoid calling new on a Promise static method'
-
 ruleTester.run('no-new-statics', rule, {
   valid: [
     'Promise.resolve()',
@@ -18,9 +16,21 @@ ruleTester.run('no-new-statics', rule, {
     'new SomeClass.resolve()'
   ],
   invalid: [
-    { code: 'new Promise.resolve()', errors: [{ message }] },
-    { code: 'new Promise.reject()', errors: [{ message }] },
-    { code: 'new Promise.all()', errors: [{ message }] },
-    { code: 'new Promise.race()', errors: [{ message }] }
+    {
+      code: 'new Promise.resolve()',
+      errors: [{ message: "Avoid calling 'new' on 'Promise.resolve()'" }]
+    },
+    {
+      code: 'new Promise.reject()',
+      errors: [{ message: "Avoid calling 'new' on 'Promise.reject()'" }]
+    },
+    {
+      code: 'new Promise.all()',
+      errors: [{ message: "Avoid calling 'new' on 'Promise.all()'" }]
+    },
+    {
+      code: 'new Promise.race()',
+      errors: [{ message: "Avoid calling 'new' on 'Promise.race()'" }]
+    }
   ]
 })

--- a/__tests__/no-new-statics.js
+++ b/__tests__/no-new-statics.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const rule = require('../rules/no-new-statics')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester()
+
+const message = 'Avoid calling new on a Promise static method'
+
+ruleTester.run('no-new-statics', rule, {
+  valid: [
+    'Promise.resolve()',
+    'Promise.reject()',
+    'Promise.all()',
+    'Promise.race()',
+    'new Promise(function (resolve, reject) {})',
+    'new SomeClass()',
+    'SomeClass.resolve()',
+    'new SomeClass.resolve()'
+  ],
+  invalid: [
+    { code: 'new Promise.resolve()', errors: [{ message }] },
+    { code: 'new Promise.reject()', errors: [{ message }] },
+    { code: 'new Promise.all()', errors: [{ message }] },
+    { code: 'new Promise.race()', errors: [{ message }] }
+  ]
+})

--- a/docs/rules/no-new-statics.md
+++ b/docs/rules/no-new-statics.md
@@ -1,0 +1,1 @@
+# Avoid calling `new` on a Promise static method (e.g. `new Promise.resolve()`) (no-new-statics)

--- a/docs/rules/no-new-statics.md
+++ b/docs/rules/no-new-statics.md
@@ -1,1 +1,32 @@
-# Avoid calling `new` on a Promise static method (e.g. `new Promise.resolve()`) (no-new-statics)
+# Avoid calling `new` on a Promise static method (no-new-statics)
+
+Calling a Promise static method with `new` is invalid, resulting in a
+`TypeError` at runtime.
+
+## Rule Details
+
+This rule is aimed at flagging instances where a Promise static method is called
+with `new`.
+
+Examples for **incorrect** code for this rule:
+
+```js
+new Promise.resolve(value)
+new Promise.reject(error)
+new Promise.race([p1, p2])
+new Promise.all([p1, p2])
+```
+
+Examples for **correct** code for this rule:
+
+```js
+Promise.resolve(value)
+Promise.reject(error)
+Promise.race([p1, p2])
+Promise.all([p1, p2])
+```
+
+## When Not To Use It
+
+If you do not want to be notified when calling `new` on a Promise static method,
+you can safely disable this rule.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'no-promise-in-callback': require('./rules/no-promise-in-callback'),
     'no-nesting': require('./rules/no-nesting'),
     'avoid-new': require('./rules/avoid-new'),
+    'no-new-statics': require('./rules/no-new-statics'),
     'no-return-in-finally': require('./rules/no-return-in-finally')
   },
   rulesConfig: {
@@ -34,6 +35,7 @@ module.exports = {
         'promise/no-promise-in-callback': 'warn',
         'promise/no-callback-in-promise': 'warn',
         'promise/avoid-new': 'warn',
+        'promise/no-new-statics': 'error',
         'promise/no-return-in-finally': 'warn'
       }
     }

--- a/rules/lib/is-promise.js
+++ b/rules/lib/is-promise.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const STATIC_METHODS = ['all', 'race', 'reject', 'resolve']
+const PROMISE_STATICS = require('./promise-statics')
 
 function isPromise(expression) {
   return (
@@ -29,7 +29,7 @@ function isPromise(expression) {
       expression.callee.type === 'MemberExpression' &&
       expression.callee.object.type === 'Identifier' &&
       expression.callee.object.name === 'Promise' &&
-      STATIC_METHODS.indexOf(expression.callee.property.name) !== -1)
+      PROMISE_STATICS.indexOf(expression.callee.property.name) !== -1)
   )
 }
 

--- a/rules/lib/promise-statics.js
+++ b/rules/lib/promise-statics.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = ['all', 'race', 'reject', 'resolve']

--- a/rules/no-new-statics.js
+++ b/rules/no-new-statics.js
@@ -19,7 +19,8 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: 'Avoid calling new on a Promise static method'
+            message: "Avoid calling 'new' on 'Promise.{{ name }}()'",
+            data: { name: node.callee.property.name }
           })
         }
       }

--- a/rules/no-new-statics.js
+++ b/rules/no-new-statics.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const PROMISE_STATICS = require('./lib/promise-statics')
+const getDocsUrl = require('./lib/get-docs-url')
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl('no-new-statics')
+    }
+  },
+  create(context) {
+    return {
+      NewExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'Promise' &&
+          PROMISE_STATICS.indexOf(node.callee.property.name) > -1
+        ) {
+          context.report({
+            node,
+            message: 'Avoid calling new on a Promise static method'
+          })
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves #75

Hoping to continue discussion from #75 to solidify this feature.

For now, I've created a new rule named `no-new-statics`, which warns if you call any of the Promise static methods with `new`. I'm open to new naming or including it in another rule, if that would be more appropriate. Feedback appreciated. 😄 