### PR TITLE
chore: include .travis.yml in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,4 @@ node_modules
 .idea
 test
 .npmignore
-travis.yml
+.travis.yml


### PR DESCRIPTION
When looking at https://unpkg.com/eslint-plugin-promise@3.6.0/, it seems like the `.travis.yml` file is not being ignored. This PR updates `.npmignore` to properly ignore that file when shipping this package to the npm registry.