### PR TITLE
docs(readme): add table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,32 @@
 
 Enforce best practices for JavaScript promises.
 
- [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
- [![travis-ci](https://travis-ci.org/xjamundx/eslint-plugin-promise.svg)](https://travis-ci.org/xjamundx/eslint-plugin-promise)
+[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+[![travis-ci](https://travis-ci.org/xjamundx/eslint-plugin-promise.svg)](https://travis-ci.org/xjamundx/eslint-plugin-promise)
 [![npm version](https://badge.fury.io/js/eslint-plugin-promise.svg)](https://www.npmjs.com/package/eslint-plugin-promise)
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Rules](#rules)
+  - [`catch-or-return`](#catch-or-return)
+  - [`no-return-wrap`](#no-return-wrap)
+  - [`param-names`](#param-names)
+  - [`always-return`](#always-return)
+  - [`no-native`](#no-native)
+  - [`no-nesting`](#no-nesting)
+  - [`no-promise-in-callback`](#no-promise-in-callback)
+  - [`no-callback-in-promise`](#no-callback-in-promise)
+  - [`avoid-new`](#avoid-new)
+  - [`no-return-in-finally`](#no-return-in-finally)
+  - [`prefer-await-to-then`](#prefer-await-to-then)
+  - [`prefer-await-to-callbacks`](#prefer-await-to-callbacks)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
 ## Installation
@@ -12,7 +35,7 @@ Enforce best practices for JavaScript promises.
 You'll first need to install [ESLint](http://eslint.org):
 
 ```
-$ npm i eslint --save-dev
+$ npm install eslint --save-dev
 ```
 
 Next, install `eslint-plugin-promise`:
@@ -34,7 +57,6 @@ Add `promise` to the plugins section of your `.eslintrc` configuration file. You
     ]
 }
 ```
-
 
 Then configure the rules you want to use under the rules section.
 
@@ -67,8 +89,6 @@ or start with the recommended rule set
 
 ## Rules
 
-### Promise Rules
-
 | recommended | rule                        | description                                                                      |
 | ----------- | --------------------------- | -------------------------------------------------------------------------------- |
 | :bangbang:  | `catch-or-return`           | Enforces the use of `catch()` on un-returned promises.                           |
@@ -92,10 +112,7 @@ or start with the recommended rule set
 | :warning:  | Reports as warning in recommended configuration |
 | :seven:    | ES2017 Async Await rules                        |
 
-[nodeify]: https://www.npmjs.com/package/nodeify
-[pify]: https://www.npmjs.com/package/pify
-
-### Rule: `catch-or-return`
+### `catch-or-return`
 
 Ensure that each time a `then()` is applied to a promise, a
 `catch()` is applied as well. Exceptions are made if you are
@@ -119,13 +136,13 @@ function doSomethingElse() { myPromise.then(doSomething) }
 
 #### Options
 
-#### `allowThen`
+##### `allowThen`
 
 You can pass an `{ allowThen: true }` as an option to this rule
  to allow for `.then(null, fn)` to be used instead of `catch()` at
  the end of the promise chain.
 
-#### `terminationMethod`
+##### `terminationMethod`
 
 You can pass a `{ terminationMethod: 'done' }` as an option to this rule
  to require `done()` instead of `catch()` at the end of the promise chain.
@@ -141,68 +158,7 @@ Promise.resolve(1).then(() => { throw new Error('oops') }).asCallback(cb)
 Promise.resolve(1).then(() => { throw new Error('oops') }).finally(cleanUp)
 ```
 
-### Rule: `always-return`
-
-Ensure that inside a `then()` you make sure to `return` a new promise or value.
-See http://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html (rule #5)
-for more info on why that's a good idea.
-
-We also allow someone to `throw` inside a `then()` which is essentially the same as `return Promise.reject()`.
-
-#### Valid
-
-```js
-myPromise.then((val) => val * 2));
-myPromise.then(function(val) { return val * 2; });
-myPromise.then(doSomething); // could be either
-myPromise.then((b) => { if (b) { return "yes" } else { return "no" } });
-```
-
-#### Invalid
-
-```js
-myPromise.then(function(val) {});
-myPromise.then(() => { doSomething(); });
-myPromise.then((b) => { if (b) { return "yes" } else { forgotToReturn(); } });
-```
-
-### `param-names`
-
-Enforce standard parameter names for Promise constructors
-
-#### Valid
-```js
-new Promise(function (resolve) { ... })
-new Promise(function (resolve, reject) { ... })
-```
-
-#### Invalid
-```js
-new Promise(function (reject, resolve) { ... }) // incorrect order
-new Promise(function (ok, fail) { ... }) // non-standard parameter names
-```
-
-Ensures that `new Promise()` is instantiated with the parameter names `resolve, reject` to avoid confusion with order such as `reject, resolve`. The Promise constructor uses the [RevealingConstructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/). Using the same parameter names as the language specification makes code more uniform and easier to understand.
-
-### `no-native`
-
-Ensure that `Promise` is included fresh in each file instead of relying
- on the existence of a native promise implementation. Helpful if you want
- to use `bluebird` or if you don't intend to use an ES6 Promise shim.
-
-
-#### Valid
-```js
-var Promise = require("bluebird");
-var x = Promise.resolve("good");
-```
-
-#### Invalid
-```js
-var x = Promise.resolve("bad");
-```
-
-### Rule: `no-return-wrap`
+### `no-return-wrap`
 
 Ensure that inside a `then()` or a `catch()` we always `return`
  or `throw` a raw value instead of wrapping in `Promise.resolve`
@@ -230,11 +186,88 @@ myPromise.then(function(val) {
 
 #### Options
 
-#### `allowReject`
+##### `allowReject`
 
 Pass `{ allowReject: true }` as an option to this rule to permit wrapping returned values with `Promise.reject`, such as when you would use it as another way to reject the promise.
 
-### Rule: `no-return-in-finally`
+### `param-names`
+
+Enforce standard parameter names for Promise constructors
+
+#### Valid
+```js
+new Promise(function (resolve) { ... })
+new Promise(function (resolve, reject) { ... })
+```
+
+#### Invalid
+```js
+new Promise(function (reject, resolve) { ... }) // incorrect order
+new Promise(function (ok, fail) { ... }) // non-standard parameter names
+```
+
+Ensures that `new Promise()` is instantiated with the parameter names `resolve, reject` to avoid confusion with order such as `reject, resolve`. The Promise constructor uses the [RevealingConstructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/). Using the same parameter names as the language specification makes code more uniform and easier to understand.
+
+### `always-return`
+
+Ensure that inside a `then()` you make sure to `return` a new promise or value.
+See http://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html (rule #5)
+for more info on why that's a good idea.
+
+We also allow someone to `throw` inside a `then()` which is essentially the same as `return Promise.reject()`.
+
+#### Valid
+
+```js
+myPromise.then((val) => val * 2));
+myPromise.then(function(val) { return val * 2; });
+myPromise.then(doSomething); // could be either
+myPromise.then((b) => { if (b) { return "yes" } else { return "no" } });
+```
+
+#### Invalid
+
+```js
+myPromise.then(function(val) {});
+myPromise.then(() => { doSomething(); });
+myPromise.then((b) => { if (b) { return "yes" } else { forgotToReturn(); } });
+```
+
+### `no-native`
+
+Ensure that `Promise` is included fresh in each file instead of relying
+ on the existence of a native promise implementation. Helpful if you want
+ to use `bluebird` or if you don't intend to use an ES6 Promise shim.
+
+
+#### Valid
+```js
+var Promise = require("bluebird");
+var x = Promise.resolve("good");
+```
+
+#### Invalid
+```js
+var x = Promise.resolve("bad");
+```
+
+### `no-nesting`
+
+Avoid nested `then()` or `catch()` statements
+
+### `no-promise-in-callback`
+
+Avoid using promises inside of callbacks
+
+### `no-callback-in-promise`
+
+Avoid calling `cb()` inside of a `then()` (use [nodeify][] instead)
+
+### `avoid-new`
+
+Avoid creating `new` promises outside of utility libs (use [pify][] instead)
+
+### `no-return-in-finally`
 
 Disallow return statements inside a callback passed to `finally()`, since nothing would consume what's returned.
 
@@ -252,7 +285,18 @@ myPromise.finally(function(val) {
 })
 ```
 
-## Etc
+### `prefer-await-to-then`
+
+Prefer `await` to `then()` for reading Promise values
+
+### `prefer-await-to-callbacks`
+
+Prefer async/await to the callback pattern
+
+## License
 
 - (c) MMXV jden <jason@denizac.org> - ISC license.
 - (c) 2016 Jamund Ferguson <jamund@gmail.com> - ISC license.
+
+[nodeify]: https://www.npmjs.com/package/nodeify
+[pify]: https://www.npmjs.com/package/pify


### PR DESCRIPTION
This PR aims to clean up the README a little bit and add a table of contents. I see this as a first step to resolving #61.

I generated the table of contents by running `npx doctoc README.md --notitle --maxlevel=3`. I wanted to set up [lint-staged](https://github.com/okonet/lint-staged) in this PR, but I had trouble installing it using Node 4 and npm 2 in my local development environment. (I'll open an issue to discuss using Node 8 and npm 5 as the preferred development environment, but continue running tests on Node 4 to continue supporting that version of Node with this ESLint plugin.)

The primary change is that all rules are documented below the **Rules** section with the following convention:

```
### `rule-name`
```

This allows for consistent documentation URLs, which now look like `https://github.com/xjamundx/eslint-plugin-promise#rule-name`.

Once this is merged, I will open a follow up PR to add the `meta.docs.url` field to all rules, which should close #61. (ESLint did a similar thing in their codebase in https://github.com/eslint/eslint/pull/9788)