### PR TITLE
refactor: resolve eslint-plugin-eslint-plugin warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,9 @@
   "plugins": [
     "eslint-plugin"
   ],
+  "extends": [
+    "plugin:eslint-plugin/recommended"
+  ],
   "rules": {
     "eslint-plugin/require-meta-docs-url": [
       "error",

--- a/rules/avoid-new.js
+++ b/rules/avoid-new.js
@@ -15,7 +15,7 @@ module.exports = {
     return {
       NewExpression: function (node) {
         if (node.callee.name === 'Promise') {
-          context.report(node, 'Avoid creating new promises.')
+          context.report({ node, message: 'Avoid creating new promises.' })
         }
       }
     }

--- a/rules/catch-or-return.js
+++ b/rules/catch-or-return.js
@@ -56,7 +56,7 @@ module.exports = {
           return
         }
 
-        context.report(node, 'Expected ' + terminationMethod + '() or return')
+        context.report({ node, message: 'Expected ' + terminationMethod + '() or return' })
       }
     }
   }

--- a/rules/no-callback-in-promise.js
+++ b/rules/no-callback-in-promise.js
@@ -26,13 +26,13 @@ module.exports = {
           if (hasPromiseCallback(node)) {
             var name = node.arguments && node.arguments[0] && node.arguments[0].name
             if (name === 'callback' || name === 'cb' || name === 'next' || name === 'done') {
-              context.report(node.arguments[0], 'Avoid calling back inside of a promise.')
+              context.report({ node: node.arguments[0], message: 'Avoid calling back inside of a promise.' })
             }
           }
           return
         }
         if (context.getAncestors().some(isInsidePromise)) {
-          context.report(node, 'Avoid calling back inside of a promise.')
+          context.report({ node, message: 'Avoid calling back inside of a promise.' })
         }
       }
     }

--- a/rules/no-native.js
+++ b/rules/no-native.js
@@ -43,7 +43,7 @@ module.exports = {
           }
 
           if (!isDeclared(scope, ref)) {
-            context.report(ref.identifier, MESSAGE, { name: ref.identifier.name })
+            context.report({ node: ref.identifier, message: MESSAGE, data: { name: ref.identifier.name } })
           }
         })
       }

--- a/rules/no-nesting.js
+++ b/rules/no-nesting.js
@@ -19,7 +19,7 @@ module.exports = {
       CallExpression: function (node) {
         if (!hasPromiseCallback(node)) return
         if (context.getAncestors().some(isInsidePromise)) {
-          context.report(node, 'Avoid nesting promises.')
+          context.report({ node, message: 'Avoid nesting promises.' })
         }
       }
     }

--- a/rules/no-promise-in-callback.js
+++ b/rules/no-promise-in-callback.js
@@ -27,7 +27,7 @@ module.exports = {
         // would that imply an implicit return?
 
         if (context.getAncestors().some(isInsideCallback)) {
-          context.report(node.callee, 'Avoid using promises inside of callbacks.')
+          context.report({ node: node.callee, message: 'Avoid using promises inside of callbacks.' })
         }
       }
     }

--- a/rules/no-return-in-finally.js
+++ b/rules/no-return-in-finally.js
@@ -15,7 +15,7 @@ module.exports = {
           if (node.callee && node.callee.property && node.callee.property.name === 'finally') {
             if (node.arguments && node.arguments[0] && node.arguments[0].body && node.arguments[0].body.body) {
               if (node.arguments[0].body.body.some(function (statement) { return statement.type === 'ReturnStatement' })) {
-                context.report(node.callee.property, 'No return in finally')
+                context.report({ node: node.callee.property, message: 'No return in finally' })
               }
             }
           }

--- a/rules/no-return-wrap.js
+++ b/rules/no-return-wrap.js
@@ -35,9 +35,9 @@ module.exports = {
               if (node.argument.callee.type === 'MemberExpression') {
                 if (node.argument.callee.object.name === 'Promise') {
                   if (node.argument.callee.property.name === 'resolve') {
-                    context.report(node, resolveMessage)
+                    context.report({ node, message: resolveMessage })
                   } else if (!allowReject && node.argument.callee.property.name === 'reject') {
-                    context.report(node, rejectMessage)
+                    context.report({ node, message: rejectMessage })
                   }
                 }
               }

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -15,11 +15,11 @@ module.exports = {
           if (!params || !params.length) { return }
 
           if (params[0].name !== 'resolve') {
-            return context.report(node, 'Promise constructor parameters must be named resolve, reject')
+            return context.report({ node, message: 'Promise constructor parameters must be named resolve, reject' })
           }
 
           if (params[1] && params[1].name !== 'reject') {
-            return context.report(node, 'Promise constructor parameters must be named resolve, reject')
+            return context.report({ node, message: 'Promise constructor parameters must be named resolve, reject' })
           }
         }
       }

--- a/rules/prefer-await-to-callbacks.js
+++ b/rules/prefer-await-to-callbacks.js
@@ -18,7 +18,7 @@ module.exports = {
       var len = node.params.length - 1
       var lastParam = node.params[len]
       if (lastParam && (lastParam.name === 'callback' || lastParam.name === 'cb')) {
-        context.report(lastParam, errorMessage)
+        context.report({ node: lastParam, message: errorMessage })
       }
     }
     function isInsideYieldOrAwait () {
@@ -30,7 +30,7 @@ module.exports = {
       CallExpression: function (node) {
         // callbacks aren't allowed
         if (node.callee.name === 'cb' || node.callee.name === 'callback') {
-          context.report(node, errorMessage)
+          context.report({ node, message: errorMessage })
           return
         }
 
@@ -41,7 +41,7 @@ module.exports = {
         if (arg && arg.type === 'FunctionExpression' || arg.type === 'ArrowFunctionExpression') {
           if (arg.params && arg.params[0] && arg.params[0].name === 'err') {
             if (!isInsideYieldOrAwait()) {
-              context.report(arg, errorMessage)
+              context.report({ node: arg, message: errorMessage })
             }
           }
         }

--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -23,7 +23,7 @@ module.exports = {
 
         // if you're a then expression then you're probably a promise
         if (node.property && node.property.name === 'then') {
-          context.report(node.property, 'Prefer await to then().')
+          context.report({ node: node.property, message: 'Prefer await to then().' })
         }
       }
     }

--- a/test/catch-or-return.test.js
+++ b/test/catch-or-return.test.js
@@ -37,7 +37,6 @@ ruleTester.run('catch-or-return', rule, {
     { code: 'frank().then(a).then(b).then(c, d)', options: [{ 'allowThen': true }] },
     { code: 'frank().then(a).then(b).then().then().then(null, doIt)', options: [{ 'allowThen': true }] },
     { code: 'frank().then(a).then(b).then(null, function() { /* why bother */ })', options: [{ 'allowThen': true }] },
-    { code: 'frank.then(go).then(to).then(null, jail)', options: [{ 'allowThen': true }] },
 
     // allowThen - .then(fn, fn)
     { code: 'frank().then(go).then(zam, doIt)', options: [{ 'allowThen': true }] },
@@ -59,27 +58,23 @@ ruleTester.run('catch-or-return', rule, {
     // catch failures
     {
       code: 'function callPromise(promise, cb) { promise.then(cb) }',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'fetch("http://www.yahoo.com").then(console.log.bind(console))',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'a.then(function() { return "x"; }).then(function(y) { throw y; })',
-      errors: [ { message: message } ]
-    },
-    {
-      code: 'a.then(function() { return "x"; }).then(function(y) { throw y; })',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'Promise.resolve(frank)',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'frank.then(to).finally(fn)',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
 
     // return failures


### PR DESCRIPTION
Resolves #89 

This PR enables the [`eslint-plugin-eslint-plugin`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) recommended configuration and resolves updating the `context.report()` API usage as well as removing a couple of duplicate test cases.