### PR TITLE
chore: update code formatting tools

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,11 +5,11 @@
   "parserOptions": {
     "ecmaVersion": 6
   },
-  "plugins": [
-    "eslint-plugin"
-  ],
+  "plugins": ["eslint-plugin", "prettier"],
   "extends": [
-    "plugin:eslint-plugin/recommended"
+    "standard",
+    "plugin:eslint-plugin/recommended",
+    "plugin:prettier/recommended"
   ],
   "rules": {
     "eslint-plugin/require-meta-docs-url": [
@@ -17,6 +17,7 @@
       {
         "pattern": "https://github.com/xjamundx/eslint-plugin-promise#{{name}}"
       }
-    ]
+    ],
+    "prettier/prettier": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,18 +12,40 @@
   "author": "jden <jason@denizac.org>",
   "repository": "git@github.com:xjamundx/eslint-plugin-promise.git",
   "scripts": {
-    "pretest": "standard",
+    "precommit": "lint-staged",
     "test": "mocha test",
-    "lint": "eslint index.js rules test"
+    "lint": "eslint index.js rules test --ignore-pattern '**/*.json'"
   },
   "devDependencies": {
+    "doctoc": "^1.3.0",
     "eslint": "^4.17.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-eslint-plugin": "^1.4.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-node": "^6.0.0",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-promise": "./",
+    "eslint-plugin-standard": "^3.0.1",
+    "husky": "^0.14.3",
+    "lint-staged": "^6.1.0",
     "mocha": "^5.0.0",
-    "standard": "^7.1.2"
+    "prettier": "^1.10.2"
   },
   "engines": {
     "node": ">=4"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "lint-staged": {
+    "concurrent": false,
+    "linters": {
+      "README.md": ["doctoc --maxlevel 3 --notitle", "git add"],
+      "*.js": ["prettier --write", "eslint --fix", "git add"],
+      "*.json": ["prettier --write", "git add"]
+    }
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  }
 }

--- a/rules/always-return.js
+++ b/rules/always-return.js
@@ -1,6 +1,6 @@
 'use strict'
 
-function isFunctionWithBlockStatement (node) {
+function isFunctionWithBlockStatement(node) {
   if (node.type === 'FunctionExpression') {
     return true
   }
@@ -10,31 +10,29 @@ function isFunctionWithBlockStatement (node) {
   return false
 }
 
-function isThenCallExpression (node) {
+function isThenCallExpression(node) {
   return (
-  node.type === 'CallExpression' &&
-  node.callee.type === 'MemberExpression' &&
-  node.callee.property.name === 'then'
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.name === 'then'
   )
 }
 
-function isFirstArgument (node) {
+function isFirstArgument(node) {
   return (
-  node.parent &&
-  node.parent.arguments &&
-  node.parent.arguments[0] === node
+    node.parent && node.parent.arguments && node.parent.arguments[0] === node
   )
 }
 
-function isInlineThenFunctionExpression (node) {
+function isInlineThenFunctionExpression(node) {
   return (
-  isFunctionWithBlockStatement(node) &&
-  isThenCallExpression(node.parent) &&
-  isFirstArgument(node)
+    isFunctionWithBlockStatement(node) &&
+    isThenCallExpression(node.parent) &&
+    isFirstArgument(node)
   )
 }
 
-function hasParentReturnStatement (node) {
+function hasParentReturnStatement(node) {
   if (node && node.parent && node.parent.type) {
     // if the parent is a then, and we haven't returned anything, fail
     if (isThenCallExpression(node.parent)) {
@@ -50,7 +48,7 @@ function hasParentReturnStatement (node) {
   return false
 }
 
-function peek (arr) {
+function peek(arr) {
   return arr[arr.length - 1]
 }
 
@@ -60,7 +58,7 @@ module.exports = {
       url: 'https://github.com/xjamundx/eslint-plugin-promise#always-return'
     }
   },
-  create: function (context) {
+  create: function(context) {
     // funcInfoStack is a stack representing the stack of currently executing
     //   functions
     // funcInfoStack[i].branchIDStack is a stack representing the currently
@@ -92,7 +90,7 @@ module.exports = {
     //             loc: <loc> } } } ]
     var funcInfoStack = []
 
-    function markCurrentBranchAsGood () {
+    function markCurrentBranchAsGood() {
       var funcInfo = peek(funcInfoStack)
       var currentBranchID = peek(funcInfo.branchIDStack)
       if (funcInfo.branchInfoMap[currentBranchID]) {
@@ -105,32 +103,32 @@ module.exports = {
       ReturnStatement: markCurrentBranchAsGood,
       ThrowStatement: markCurrentBranchAsGood,
 
-      onCodePathSegmentStart: function (segment, node) {
+      onCodePathSegmentStart: function(segment, node) {
         var funcInfo = peek(funcInfoStack)
         funcInfo.branchIDStack.push(segment.id)
-        funcInfo.branchInfoMap[segment.id] = {good: false, node: node}
+        funcInfo.branchInfoMap[segment.id] = { good: false, node: node }
       },
 
-      onCodePathSegmentEnd: function (segment, node) {
+      onCodePathSegmentEnd: function(segment, node) {
         var funcInfo = peek(funcInfoStack)
         funcInfo.branchIDStack.pop()
       },
 
-      onCodePathStart: function (path, node) {
+      onCodePathStart: function(path, node) {
         funcInfoStack.push({
           branchIDStack: [],
           branchInfoMap: {}
         })
       },
 
-      onCodePathEnd: function (path, node) {
+      onCodePathEnd: function(path, node) {
         var funcInfo = funcInfoStack.pop()
 
         if (!isInlineThenFunctionExpression(node)) {
           return
         }
 
-        path.finalSegments.forEach((segment) => {
+        path.finalSegments.forEach(segment => {
           var id = segment.id
           var branch = funcInfo.branchInfoMap[id]
           if (!branch.good) {

--- a/rules/avoid-new.js
+++ b/rules/avoid-new.js
@@ -11,9 +11,9 @@ module.exports = {
       url: 'https://github.com/xjamundx/eslint-plugin-promise#avoid-new'
     }
   },
-  create: function (context) {
+  create: function(context) {
     return {
-      NewExpression: function (node) {
+      NewExpression: function(node) {
         if (node.callee.name === 'Promise') {
           context.report({ node, message: 'Avoid creating new promises.' })
         }

--- a/rules/catch-or-return.js
+++ b/rules/catch-or-return.js
@@ -14,7 +14,7 @@ module.exports = {
       url: 'https://github.com/xjamundx/eslint-plugin-promise#catch-or-return'
     }
   },
-  create: function (context) {
+  create: function(context) {
     var options = context.options[0] || {}
     var allowThen = options.allowThen
     var terminationMethod = options.terminationMethod || 'catch'
@@ -24,13 +24,14 @@ module.exports = {
     }
 
     return {
-      ExpressionStatement: function (node) {
+      ExpressionStatement: function(node) {
         if (!isPromise(node.expression)) {
           return
         }
 
         // somePromise.then(a, b)
-        if (allowThen &&
+        if (
+          allowThen &&
           node.expression.type === 'CallExpression' &&
           node.expression.callee.type === 'MemberExpression' &&
           node.expression.callee.property.name === 'then' &&
@@ -40,7 +41,8 @@ module.exports = {
         }
 
         // somePromise.catch()
-        if (node.expression.type === 'CallExpression' &&
+        if (
+          node.expression.type === 'CallExpression' &&
           node.expression.callee.type === 'MemberExpression' &&
           terminationMethod.indexOf(node.expression.callee.property.name) !== -1
         ) {
@@ -48,7 +50,8 @@ module.exports = {
         }
 
         // somePromise['catch']()
-        if (node.expression.type === 'CallExpression' &&
+        if (
+          node.expression.type === 'CallExpression' &&
           node.expression.callee.type === 'MemberExpression' &&
           node.expression.callee.property.type === 'Literal' &&
           node.expression.callee.property.value === 'catch'
@@ -56,7 +59,10 @@ module.exports = {
           return
         }
 
-        context.report({ node, message: 'Expected ' + terminationMethod + '() or return' })
+        context.report({
+          node,
+          message: 'Expected ' + terminationMethod + '() or return'
+        })
       }
     }
   }

--- a/rules/lib/has-promise-callback.js
+++ b/rules/lib/has-promise-callback.js
@@ -6,7 +6,7 @@
 
 'use strict'
 
-function hasPromiseCallback (node) {
+function hasPromiseCallback(node) {
   if (node.type !== 'CallExpression') return
   if (node.callee.type !== 'MemberExpression') return
   var propertyName = node.callee.property.name

--- a/rules/lib/is-callback.js
+++ b/rules/lib/is-callback.js
@@ -2,7 +2,7 @@
 
 var isNamedCallback = require('./is-named-callback')
 
-function isCallingBack (node, exceptions) {
+function isCallingBack(node, exceptions) {
   var isCallExpression = node.type === 'CallExpression'
   var callee = node.callee || {}
   var nameIsCallback = isNamedCallback(callee.name, exceptions)

--- a/rules/lib/is-inside-callback.js
+++ b/rules/lib/is-inside-callback.js
@@ -2,8 +2,9 @@
 
 var isInsidePromise = require('./is-inside-promise')
 
-function isInsideCallback (node) {
-  var isCallExpression = node.type === 'FunctionExpression' ||
+function isInsideCallback(node) {
+  var isCallExpression =
+    node.type === 'FunctionExpression' ||
     node.type === 'ArrowFunctionExpression' ||
     node.type === 'FunctionDeclaration' // this may be controversial
 

--- a/rules/lib/is-inside-promise.js
+++ b/rules/lib/is-inside-promise.js
@@ -1,11 +1,12 @@
 'use strict'
 
-function isInsidePromise (node) {
-  var isFunctionExpression = node.type === 'FunctionExpression' ||
-      node.type === 'ArrowFunctionExpression'
+function isInsidePromise(node) {
+  var isFunctionExpression =
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
   var parent = node.parent || {}
   var callee = parent.callee || {}
-  var name = callee.property && callee.property.name || ''
+  var name = (callee.property && callee.property.name) || ''
   var parentIsPromise = name === 'then' || name === 'catch'
   var isInCB = isFunctionExpression && parentIsPromise
   return isInCB

--- a/rules/lib/is-named-callback.js
+++ b/rules/lib/is-named-callback.js
@@ -2,11 +2,13 @@
 
 var callbacks = ['done', 'cb', 'callback', 'next']
 
-module.exports = function isNamedCallback (potentialCallbackName, exceptions) {
+module.exports = function isNamedCallback(potentialCallbackName, exceptions) {
   for (var i = 0; i < exceptions.length; i++) {
-    callbacks = callbacks.filter(function (item) { return item !== exceptions[i] })
+    callbacks = callbacks.filter(function(item) {
+      return item !== exceptions[i]
+    })
   }
-  return callbacks.some(function (trueCallbackName) {
+  return callbacks.some(function(trueCallbackName) {
     return potentialCallbackName === trueCallbackName
   })
 }

--- a/rules/lib/is-promise.js
+++ b/rules/lib/is-promise.js
@@ -4,36 +4,32 @@
  */
 'use strict'
 
-var STATIC_METHODS = [
-  'all',
-  'race',
-  'reject',
-  'resolve'
-]
+var STATIC_METHODS = ['all', 'race', 'reject', 'resolve']
 
-function isPromise (expression) {
-  return ( // hello.then()
-  expression.type === 'CallExpression' &&
-  expression.callee.type === 'MemberExpression' &&
-  expression.callee.property.name === 'then'
-  ) || ( // hello.catch()
-  expression.type === 'CallExpression' &&
-  expression.callee.type === 'MemberExpression' &&
-  expression.callee.property.name === 'catch'
-  ) || ( // hello.finally()
-  expression.type === 'CallExpression' &&
-  expression.callee.type === 'MemberExpression' &&
-  expression.callee.property.name === 'finally'
-  ) || ( // somePromise.ANYTHING()
-  expression.type === 'CallExpression' &&
-  expression.callee.type === 'MemberExpression' &&
-  isPromise(expression.callee.object)
-  ) || ( // Promise.STATIC_METHOD()
-  expression.type === 'CallExpression' &&
-  expression.callee.type === 'MemberExpression' &&
-  expression.callee.object.type === 'Identifier' &&
-  expression.callee.object.name === 'Promise' &&
-  STATIC_METHODS.indexOf(expression.callee.property.name) !== -1
+function isPromise(expression) {
+  return (
+    // hello.then()
+    (expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      expression.callee.property.name === 'then') ||
+    // hello.catch()
+    (expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      expression.callee.property.name === 'catch') ||
+    // hello.finally()
+    (expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      expression.callee.property.name === 'finally') ||
+    // somePromise.ANYTHING()
+    (expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      isPromise(expression.callee.object)) ||
+    // Promise.STATIC_METHOD()
+    (expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      expression.callee.object.type === 'Identifier' &&
+      expression.callee.object.name === 'Promise' &&
+      STATIC_METHODS.indexOf(expression.callee.property.name) !== -1)
   )
 }
 

--- a/rules/no-callback-in-promise.js
+++ b/rules/no-callback-in-promise.js
@@ -12,27 +12,40 @@ var isCallback = require('./lib/is-callback')
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-callback-in-promise'
+      url:
+        'https://github.com/xjamundx/eslint-plugin-promise#no-callback-in-promise'
     }
   },
-  create: function (context) {
+  create: function(context) {
     return {
-      CallExpression: function (node) {
+      CallExpression: function(node) {
         var options = context.options[0] || {}
         var exceptions = options.exceptions || []
         if (!isCallback(node, exceptions)) {
           // in general we send you packing if you're not a callback
           // but we also need to watch out for whatever.then(cb)
           if (hasPromiseCallback(node)) {
-            var name = node.arguments && node.arguments[0] && node.arguments[0].name
-            if (name === 'callback' || name === 'cb' || name === 'next' || name === 'done') {
-              context.report({ node: node.arguments[0], message: 'Avoid calling back inside of a promise.' })
+            var name =
+              node.arguments && node.arguments[0] && node.arguments[0].name
+            if (
+              name === 'callback' ||
+              name === 'cb' ||
+              name === 'next' ||
+              name === 'done'
+            ) {
+              context.report({
+                node: node.arguments[0],
+                message: 'Avoid calling back inside of a promise.'
+              })
             }
           }
           return
         }
         if (context.getAncestors().some(isInsidePromise)) {
-          context.report({ node, message: 'Avoid calling back inside of a promise.' })
+          context.report({
+            node,
+            message: 'Avoid calling back inside of a promise.'
+          })
         }
       }
     }

--- a/rules/no-native.js
+++ b/rules/no-native.js
@@ -3,8 +3,8 @@
 
 'use strict'
 
-function isDeclared (scope, ref) {
-  return scope.variables.some(function (variable) {
+function isDeclared(scope, ref) {
+  return scope.variables.some(function(variable) {
     if (variable.name !== ref.identifier.name) {
       return false
     }
@@ -23,7 +23,7 @@ module.exports = {
       url: 'https://github.com/xjamundx/eslint-plugin-promise#no-native'
     }
   },
-  create: function (context) {
+  create: function(context) {
     var MESSAGE = '"{{name}}" is not defined.'
 
     /**
@@ -34,16 +34,20 @@ module.exports = {
      * @private
      */
     return {
-      'Program:exit': function () {
+      'Program:exit': function() {
         var scope = context.getScope()
 
-        scope.implicit.left.forEach(function (ref) {
+        scope.implicit.left.forEach(function(ref) {
           if (ref.identifier.name !== 'Promise') {
             return
           }
 
           if (!isDeclared(scope, ref)) {
-            context.report({ node: ref.identifier, message: MESSAGE, data: { name: ref.identifier.name } })
+            context.report({
+              node: ref.identifier,
+              message: MESSAGE,
+              data: { name: ref.identifier.name }
+            })
           }
         })
       }

--- a/rules/no-nesting.js
+++ b/rules/no-nesting.js
@@ -14,9 +14,9 @@ module.exports = {
       url: 'https://github.com/xjamundx/eslint-plugin-promise#no-nesting'
     }
   },
-  create: function (context) {
+  create: function(context) {
     return {
-      CallExpression: function (node) {
+      CallExpression: function(node) {
         if (!hasPromiseCallback(node)) return
         if (context.getAncestors().some(isInsidePromise)) {
           context.report({ node, message: 'Avoid nesting promises.' })

--- a/rules/no-promise-in-callback.js
+++ b/rules/no-promise-in-callback.js
@@ -11,12 +11,13 @@ var isInsideCallback = require('./lib/is-inside-callback')
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-promise-in-callback'
+      url:
+        'https://github.com/xjamundx/eslint-plugin-promise#no-promise-in-callback'
     }
   },
-  create: function (context) {
+  create: function(context) {
     return {
-      CallExpression: function (node) {
+      CallExpression: function(node) {
         if (!isPromise(node)) return
 
         // if i'm returning the promise, it's probably not really a callback
@@ -27,7 +28,10 @@ module.exports = {
         // would that imply an implicit return?
 
         if (context.getAncestors().some(isInsideCallback)) {
-          context.report({ node: node.callee, message: 'Avoid using promises inside of callbacks.' })
+          context.report({
+            node: node.callee,
+            message: 'Avoid using promises inside of callbacks.'
+          })
         }
       }
     }

--- a/rules/no-return-in-finally.js
+++ b/rules/no-return-in-finally.js
@@ -5,17 +5,34 @@ var isPromise = require('./lib/is-promise')
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-return-in-finally'
+      url:
+        'https://github.com/xjamundx/eslint-plugin-promise#no-return-in-finally'
     }
   },
-  create: function (context) {
+  create: function(context) {
     return {
-      CallExpression: function (node) {
+      CallExpression: function(node) {
         if (isPromise(node)) {
-          if (node.callee && node.callee.property && node.callee.property.name === 'finally') {
-            if (node.arguments && node.arguments[0] && node.arguments[0].body && node.arguments[0].body.body) {
-              if (node.arguments[0].body.body.some(function (statement) { return statement.type === 'ReturnStatement' })) {
-                context.report({ node: node.callee.property, message: 'No return in finally' })
+          if (
+            node.callee &&
+            node.callee.property &&
+            node.callee.property.name === 'finally'
+          ) {
+            if (
+              node.arguments &&
+              node.arguments[0] &&
+              node.arguments[0].body &&
+              node.arguments[0].body.body
+            ) {
+              if (
+                node.arguments[0].body.body.some(function(statement) {
+                  return statement.type === 'ReturnStatement'
+                })
+              ) {
+                context.report({
+                  node: node.callee.property,
+                  message: 'No return in finally'
+                })
               }
             }
           }

--- a/rules/no-return-wrap.js
+++ b/rules/no-return-wrap.js
@@ -10,8 +10,8 @@ var isPromise = require('./lib/is-promise')
 var rejectMessage = 'Expected throw instead of Promise.reject'
 var resolveMessage = 'Avoid wrapping return values in Promise.resolve'
 
-function isInPromise (context) {
-  var expression = context.getAncestors().filter(function (node) {
+function isInPromise(context) {
+  var expression = context.getAncestors().filter(function(node) {
     return node.type === 'ExpressionStatement'
   })[0]
   return expression && expression.expression && isPromise(expression.expression)
@@ -23,12 +23,12 @@ module.exports = {
       url: 'https://github.com/xjamundx/eslint-plugin-promise#no-return-wrap'
     }
   },
-  create: function (context) {
+  create: function(context) {
     var options = context.options[0] || {}
     var allowReject = options.allowReject
 
     return {
-      ReturnStatement: function (node) {
+      ReturnStatement: function(node) {
         if (isInPromise(context)) {
           if (node.argument) {
             if (node.argument.type === 'CallExpression') {
@@ -36,7 +36,10 @@ module.exports = {
                 if (node.argument.callee.object.name === 'Promise') {
                   if (node.argument.callee.property.name === 'resolve') {
                     context.report({ node, message: resolveMessage })
-                  } else if (!allowReject && node.argument.callee.property.name === 'reject') {
+                  } else if (
+                    !allowReject &&
+                    node.argument.callee.property.name === 'reject'
+                  ) {
                     context.report({ node, message: rejectMessage })
                   }
                 }

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -6,20 +6,30 @@ module.exports = {
       url: 'https://github.com/xjamundx/eslint-plugin-promise#param-names'
     }
   },
-  create: function (context) {
+  create: function(context) {
     return {
-      NewExpression: function (node) {
+      NewExpression: function(node) {
         if (node.callee.name === 'Promise' && node.arguments.length === 1) {
           var params = node.arguments[0].params
 
-          if (!params || !params.length) { return }
+          if (!params || !params.length) {
+            return
+          }
 
           if (params[0].name !== 'resolve') {
-            return context.report({ node, message: 'Promise constructor parameters must be named resolve, reject' })
+            return context.report({
+              node,
+              message:
+                'Promise constructor parameters must be named resolve, reject'
+            })
           }
 
           if (params[1] && params[1].name !== 'reject') {
-            return context.report({ node, message: 'Promise constructor parameters must be named resolve, reject' })
+            return context.report({
+              node,
+              message:
+                'Promise constructor parameters must be named resolve, reject'
+            })
           }
         }
       }

--- a/rules/prefer-await-to-callbacks.js
+++ b/rules/prefer-await-to-callbacks.js
@@ -10,24 +10,30 @@ var errorMessage = 'Avoid callbacks. Prefer Async/Await.'
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#prefer-await-to-callbacks'
+      url:
+        'https://github.com/xjamundx/eslint-plugin-promise#prefer-await-to-callbacks'
     }
   },
-  create: function (context) {
-    function checkLastParamsForCallback (node) {
+  create: function(context) {
+    function checkLastParamsForCallback(node) {
       var len = node.params.length - 1
       var lastParam = node.params[len]
-      if (lastParam && (lastParam.name === 'callback' || lastParam.name === 'cb')) {
+      if (
+        lastParam &&
+        (lastParam.name === 'callback' || lastParam.name === 'cb')
+      ) {
         context.report({ node: lastParam, message: errorMessage })
       }
     }
-    function isInsideYieldOrAwait () {
-      return context.getAncestors().some(function (parent) {
-        return parent.type === 'AwaitExpression' || parent.type === 'YieldExpression'
+    function isInsideYieldOrAwait() {
+      return context.getAncestors().some(function(parent) {
+        return (
+          parent.type === 'AwaitExpression' || parent.type === 'YieldExpression'
+        )
       })
     }
     return {
-      CallExpression: function (node) {
+      CallExpression: function(node) {
         // callbacks aren't allowed
         if (node.callee.name === 'cb' || node.callee.name === 'callback') {
           context.report({ node, message: errorMessage })
@@ -38,7 +44,10 @@ module.exports = {
         var args = node.arguments
         var num = args.length - 1
         var arg = num > -1 && node.arguments && node.arguments[num]
-        if (arg && arg.type === 'FunctionExpression' || arg.type === 'ArrowFunctionExpression') {
+        if (
+          (arg && arg.type === 'FunctionExpression') ||
+          arg.type === 'ArrowFunctionExpression'
+        ) {
           if (arg.params && arg.params[0] && arg.params[0].name === 'err') {
             if (!isInsideYieldOrAwait()) {
               context.report({ node: arg, message: errorMessage })

--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -8,22 +8,31 @@
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#prefer-await-to-then'
+      url:
+        'https://github.com/xjamundx/eslint-plugin-promise#prefer-await-to-then'
     }
   },
-  create: function (context) {
+  create: function(context) {
     return {
-      MemberExpression: function (node) {
+      MemberExpression: function(node) {
         // you can then() if you are inside of a yield or await
-        if (context.getAncestors().some(function (parent) {
-          return parent.type === 'AwaitExpression' || parent.type === 'YieldExpression'
-        })) {
+        if (
+          context.getAncestors().some(function(parent) {
+            return (
+              parent.type === 'AwaitExpression' ||
+              parent.type === 'YieldExpression'
+            )
+          })
+        ) {
           return
         }
 
         // if you're a then expression then you're probably a promise
         if (node.property && node.property.name === 'then') {
-          context.report({ node: node.property, message: 'Prefer await to then().' })
+          context.report({
+            node: node.property,
+            message: 'Prefer await to then().'
+          })
         }
       }
     }

--- a/test/always-return.test.js
+++ b/test/always-return.test.js
@@ -10,25 +10,78 @@ ruleTester.run('always-return', rule, {
     { code: 'hey.then(x => x)', parserOptions: parserOptions },
     { code: 'hey.then(x => ({}))', parserOptions: parserOptions },
     { code: 'hey.then(x => { return; })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { return x ? x.id : null })', parserOptions: parserOptions },
+    {
+      code: 'hey.then(x => { return x ? x.id : null })',
+      parserOptions: parserOptions
+    },
     { code: 'hey.then(x => { return x * 10 })', parserOptions: parserOptions },
-    { code: 'hey.then(function() { return 42; })', parserOptions: parserOptions },
-    { code: 'hey.then(function() { return new Promise(); })', parserOptions: parserOptions },
+    {
+      code: 'hey.then(function() { return 42; })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(function() { return new Promise(); })',
+      parserOptions: parserOptions
+    },
     { code: 'hey.then(function() { return "x"; }).then(doSomethingWicked)' },
-    { code: 'hey.then(x => x).then(function() { return "3" })', parserOptions: parserOptions },
-    { code: 'hey.then(function() { throw new Error("msg"); })', parserOptions: parserOptions },
-    { code: 'hey.then(function(x) { if (!x) { throw new Error("no x"); } return x; })', parserOptions: parserOptions },
-    { code: 'hey.then(function(x) { if (x) { return x; } throw new Error("no x"); })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { throw new Error("msg"); })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { if (!x) { throw new Error("no x"); } return x; })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { if (x) { return x; } throw new Error("no x"); })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { var f = function() { }; return f; })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { if (x) { return x; } else { return x; } })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { return x; var y = "unreachable"; })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { return x; return "unreachable"; })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { return; }, err=>{ log(err); })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { return x && x(); }, err=>{ log(err); })', parserOptions: parserOptions },
-    { code: 'hey.then(x => { return x.y || x(); }, err=>{ log(err); })', parserOptions: parserOptions },
+    {
+      code: 'hey.then(x => x).then(function() { return "3" })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(function() { throw new Error("msg"); })',
+      parserOptions: parserOptions
+    },
+    {
+      code:
+        'hey.then(function(x) { if (!x) { throw new Error("no x"); } return x; })',
+      parserOptions: parserOptions
+    },
+    {
+      code:
+        'hey.then(function(x) { if (x) { return x; } throw new Error("no x"); })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { throw new Error("msg"); })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { if (!x) { throw new Error("no x"); } return x; })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { if (x) { return x; } throw new Error("no x"); })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { var f = function() { }; return f; })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { if (x) { return x; } else { return x; } })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { return x; var y = "unreachable"; })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { return x; return "unreachable"; })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { return; }, err=>{ log(err); })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { return x && x(); }, err=>{ log(err); })',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'hey.then(x => { return x.y || x(); }, err=>{ log(err); })',
+      parserOptions: parserOptions
+    },
     {
       code: `hey.then(x => {
         return anotherFunc({
@@ -46,52 +99,53 @@ ruleTester.run('always-return', rule, {
     {
       code: 'hey.then(x => {})',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { })',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { }).then(x)',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { }).then(function() { })',
-      errors: [ { message: message }, { message: message } ]
+      errors: [{ message: message }, { message: message }]
     },
     {
       code: 'hey.then(function() { return; }).then(function() { })',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { doSomethingWicked(); })',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { if (x) { return x; } })',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { if (x) { return x; } else { }})',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { if (x) { } else { return x; }})',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
-      code: 'hey.then(function() { if (x) { return you.then(function() { return x; }); } })',
-      errors: [ { message: message } ]
+      code:
+        'hey.then(function() { if (x) { return you.then(function() { return x; }); } })',
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then( x => { x ? x.id : null })',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function(x) { x ? x.id : null })',
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: `(function() {
@@ -105,7 +159,7 @@ ruleTester.run('always-return', rule, {
         })
       })()`,
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     }
   ]
 })

--- a/test/avoid-new.js
+++ b/test/avoid-new.js
@@ -18,8 +18,20 @@ ruleTester.run('avoid-new', rule, {
   ],
 
   invalid: [
-    {code: 'var x = new Promise(function (x, y) {})', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'new Promise()', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'Thing(new Promise(() => {}))', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}}
+    {
+      code: 'var x = new Promise(function (x, y) {})',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'new Promise()',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'Thing(new Promise(() => {}))',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    }
   ]
 })

--- a/test/catch-or-return.test.js
+++ b/test/catch-or-return.test.js
@@ -6,7 +6,6 @@ var message = 'Expected catch() or return'
 var ruleTester = new RuleTester()
 ruleTester.run('catch-or-return', rule, {
   valid: [
-
     // catch
     'frank().then(go).catch(doIt)',
     'frank().then(go).then().then().then().catch(doIt)',
@@ -17,7 +16,11 @@ ruleTester.run('catch-or-return', rule, {
     'frank.then(to).finally(fn).catch(jail)',
 
     // arrow function use case
-    { code: 'postJSON("/smajobber/api/reportJob.json")\n\t.then(()=>this.setState())\n\t.catch(()=>this.setState())', parserOptions: { ecmaVersion: 6 } },
+    {
+      code:
+        'postJSON("/smajobber/api/reportJob.json")\n\t.then(()=>this.setState())\n\t.catch(()=>this.setState())',
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // return
     'function a() { return frank().then(go) }',
@@ -26,35 +29,85 @@ ruleTester.run('catch-or-return', rule, {
     'function a() { return frank.then(go).then(to) }',
 
     // allowThen - .then(null, fn)
-    { code: 'frank().then(go).then(null, doIt)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(go).then().then().then().then(null, doIt)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(go).then().then(null, function() { /* why bother */ })', options: [{ 'allowThen': true }] },
-    { code: 'frank.then(go).then(to).then(null, jail)', options: [{ 'allowThen': true }] },
+    {
+      code: 'frank().then(go).then(null, doIt)',
+      options: [{ allowThen: true }]
+    },
+    {
+      code: 'frank().then(go).then().then().then().then(null, doIt)',
+      options: [{ allowThen: true }]
+    },
+    {
+      code:
+        'frank().then(go).then().then(null, function() { /* why bother */ })',
+      options: [{ allowThen: true }]
+    },
+    {
+      code: 'frank.then(go).then(to).then(null, jail)',
+      options: [{ allowThen: true }]
+    },
 
     // allowThen - .then(null, fn)
-    { code: 'frank().then(a, b)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(a).then(b).then(null, c)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(a).then(b).then(c, d)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(a).then(b).then().then().then(null, doIt)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(a).then(b).then(null, function() { /* why bother */ })', options: [{ 'allowThen': true }] },
+    { code: 'frank().then(a, b)', options: [{ allowThen: true }] },
+    {
+      code: 'frank().then(a).then(b).then(null, c)',
+      options: [{ allowThen: true }]
+    },
+    {
+      code: 'frank().then(a).then(b).then(c, d)',
+      options: [{ allowThen: true }]
+    },
+    {
+      code: 'frank().then(a).then(b).then().then().then(null, doIt)',
+      options: [{ allowThen: true }]
+    },
+    {
+      code:
+        'frank().then(a).then(b).then(null, function() { /* why bother */ })',
+      options: [{ allowThen: true }]
+    },
 
     // allowThen - .then(fn, fn)
-    { code: 'frank().then(go).then(zam, doIt)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(go).then().then().then().then(wham, doIt)', options: [{ 'allowThen': true }] },
-    { code: 'frank().then(go).then().then(function() {}, function() { /* why bother */ })', options: [{ 'allowThen': true }] },
-    { code: 'frank.then(go).then(to).then(pewPew, jail)', options: [{ 'allowThen': true }] },
+    {
+      code: 'frank().then(go).then(zam, doIt)',
+      options: [{ allowThen: true }]
+    },
+    {
+      code: 'frank().then(go).then().then().then().then(wham, doIt)',
+      options: [{ allowThen: true }]
+    },
+    {
+      code:
+        'frank().then(go).then().then(function() {}, function() { /* why bother */ })',
+      options: [{ allowThen: true }]
+    },
+    {
+      code: 'frank.then(go).then(to).then(pewPew, jail)',
+      options: [{ allowThen: true }]
+    },
 
     // terminationMethod=done - .done(null, fn)
-    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': 'done' }] },
+    {
+      code: 'frank().then(go).done()',
+      options: [{ terminationMethod: 'done' }]
+    },
 
     // terminationMethod=[catch, done] - .done(null, fn)
-    { code: 'frank().then(go).catch()', options: [{ 'terminationMethod': ['catch', 'done'] }] },
-    { code: 'frank().then(go).done()', options: [{ 'terminationMethod': ['catch', 'done'] }] },
-    { code: 'frank().then(go).finally()', options: [{ 'terminationMethod': ['catch', 'finally'] }] }
+    {
+      code: 'frank().then(go).catch()',
+      options: [{ terminationMethod: ['catch', 'done'] }]
+    },
+    {
+      code: 'frank().then(go).done()',
+      options: [{ terminationMethod: ['catch', 'done'] }]
+    },
+    {
+      code: 'frank().then(go).finally()',
+      options: [{ terminationMethod: ['catch', 'finally'] }]
+    }
   ],
 
   invalid: [
-
     // catch failures
     {
       code: 'function callPromise(promise, cb) { promise.then(cb) }',
@@ -78,13 +131,33 @@ ruleTester.run('catch-or-return', rule, {
     },
 
     // return failures
-    { code: 'function a() { frank().then(go) }', errors: [{ message: message }] },
-    { code: 'function a() { frank().then(go).then().then().then() }', errors: [{ message: message }] },
-    { code: 'function a() { frank().then(go).then()}', errors: [{ message: message }] },
-    { code: 'function a() { frank.then(go).then(to) }', errors: [{ message: message }] },
+    {
+      code: 'function a() { frank().then(go) }',
+      errors: [{ message: message }]
+    },
+    {
+      code: 'function a() { frank().then(go).then().then().then() }',
+      errors: [{ message: message }]
+    },
+    {
+      code: 'function a() { frank().then(go).then()}',
+      errors: [{ message: message }]
+    },
+    {
+      code: 'function a() { frank.then(go).then(to) }',
+      errors: [{ message: message }]
+    },
 
     // terminationMethod=done - .done(null, fn)
-    { code: 'frank().then(go)', options: [{ 'terminationMethod': 'done' }], errors: [{ message: 'Expected done() or return' }] },
-    { code: 'frank().catch(go)', options: [{ 'terminationMethod': 'done' }], errors: [{ message: 'Expected done() or return' }] }
+    {
+      code: 'frank().then(go)',
+      options: [{ terminationMethod: 'done' }],
+      errors: [{ message: 'Expected done() or return' }]
+    },
+    {
+      code: 'frank().catch(go)',
+      options: [{ terminationMethod: 'done' }],
+      errors: [{ message: 'Expected done() or return' }]
+    }
   ]
 })

--- a/test/no-callback-in-promise.js
+++ b/test/no-callback-in-promise.js
@@ -15,25 +15,76 @@ ruleTester.run('no-callback-in-promise', rule, {
     'doSomething(function(err) { callback(err) })',
 
     // arrow functions and other things
-    {code: 'let thing = (cb) => cb()', parserOptions: {ecmaVersion: 6}},
-    {code: 'doSomething(err => cb(err))', parserOptions: {ecmaVersion: 6}},
+    { code: 'let thing = (cb) => cb()', parserOptions: { ecmaVersion: 6 } },
+    { code: 'doSomething(err => cb(err))', parserOptions: { ecmaVersion: 6 } },
 
     // exceptions test
-    {code: 'a.then(() => next())', parserOptions: {ecmaVersion: 6}, options: [{ 'exceptions': ['next'] }]}
+    {
+      code: 'a.then(() => next())',
+      parserOptions: { ecmaVersion: 6 },
+      options: [{ exceptions: ['next'] }]
+    }
   ],
 
   invalid: [
-    {code: 'a.then(cb)', errors: [{message: errorMessage, column: 8}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.then(() => cb())', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.then(function(err) { cb(err) })', errors: [{message: errorMessage, column: 24}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.then(function(data) { cb(data) }, function(err) { cb(err) })', errors: [{column: 25, message: errorMessage}, {column: 53, message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.catch(function(err) { cb(err) })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
+    {
+      code: 'a.then(cb)',
+      errors: [{ message: errorMessage, column: 8 }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a.then(() => cb())',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a.then(function(err) { cb(err) })',
+      errors: [{ message: errorMessage, column: 24 }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a.then(function(data) { cb(data) }, function(err) { cb(err) })',
+      errors: [
+        { column: 25, message: errorMessage },
+        { column: 53, message: errorMessage }
+      ],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a.catch(function(err) { cb(err) })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // callback should also complain
-    {code: 'a.then(callback)', errors: [{message: errorMessage, column: 8}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.then(() => callback())', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.then(function(err) { callback(err) })', errors: [{message: errorMessage, column: 24}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.then(function(data) { callback(data) }, function(err) { callback(err) })', errors: [{message: errorMessage}, {column: 59, message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a.catch(function(err) { callback(err) })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}}
+    {
+      code: 'a.then(callback)',
+      errors: [{ message: errorMessage, column: 8 }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a.then(() => callback())',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a.then(function(err) { callback(err) })',
+      errors: [{ message: errorMessage, column: 24 }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code:
+        'a.then(function(data) { callback(data) }, function(err) { callback(err) })',
+      errors: [
+        { message: errorMessage },
+        { column: 59, message: errorMessage }
+      ],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a.catch(function(err) { callback(err) })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    }
   ]
 })

--- a/test/no-native.js
+++ b/test/no-native.js
@@ -8,40 +8,50 @@ ruleTester.run('no-native', rule, {
   valid: [
     'var Promise = null; function x() { return Promise.resolve("hi"); }',
     'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();',
-    { code: 'var Promise = null; function x() { return Promise.resolve("hi"); }', parserOptions: parserOptions },
-    { code: 'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();', parserOptions: parserOptions },
-    { code: 'import Promise from "bluebird"; var x = Promise.reject();', parserOptions: parserOptions }
+    {
+      code:
+        'var Promise = null; function x() { return Promise.resolve("hi"); }',
+      parserOptions: parserOptions
+    },
+    {
+      code:
+        'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'import Promise from "bluebird"; var x = Promise.reject();',
+      parserOptions: parserOptions
+    }
   ],
 
   invalid: [
     {
       code: 'new Promise(function(reject, resolve) { })',
-      errors: [ { message: '"Promise" is not defined.' } ]
+      errors: [{ message: '"Promise" is not defined.' }]
     },
     {
       code: 'Promise.resolve()',
-      errors: [ { message: '"Promise" is not defined.' } ]
+      errors: [{ message: '"Promise" is not defined.' }]
     },
     {
       code: 'new Promise(function(reject, resolve) { })',
-      errors: [ { message: '"Promise" is not defined.' } ],
+      errors: [{ message: '"Promise" is not defined.' }],
       env: { browser: true }
     },
     {
       code: 'new Promise(function(reject, resolve) { })',
-      errors: [ { message: '"Promise" is not defined.' } ],
+      errors: [{ message: '"Promise" is not defined.' }],
       env: { node: true }
     },
     {
       code: 'Promise.resolve()',
-      errors: [ { message: '"Promise" is not defined.' } ],
+      errors: [{ message: '"Promise" is not defined.' }],
       env: { es6: true }
     },
     {
       code: 'Promise.resolve()',
-      errors: [ { message: '"Promise" is not defined.' } ],
+      errors: [{ message: '"Promise" is not defined.' }],
       globals: { Promise: true }
     }
-
   ]
 })

--- a/test/no-nesting.js
+++ b/test/no-nesting.js
@@ -9,7 +9,6 @@ var errorMessage = 'Avoid nesting promises.'
 
 ruleTester.run('no-nesting', rule, {
   valid: [
-
     // resolve and reject are sometimes okay
     'Promise.resolve(4).then(function(x) { return x })',
     'Promise.reject(4).then(function(x) { return x })',
@@ -25,12 +24,24 @@ ruleTester.run('no-nesting', rule, {
     'doThing().catch(null, function() { throw 4 })',
 
     // arrow functions and other things
-    {code: 'doThing().then(() => 4)', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => { throw 4 })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(()=>{}, () => 4)', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(()=>{}, () => { throw 4 })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().catch(() => 4)', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().catch(() => { throw 4 })', parserOptions: {ecmaVersion: 6}},
+    { code: 'doThing().then(() => 4)', parserOptions: { ecmaVersion: 6 } },
+    {
+      code: 'doThing().then(() => { throw 4 })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(()=>{}, () => 4)',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(()=>{}, () => { throw 4 })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    { code: 'doThing().catch(() => 4)', parserOptions: { ecmaVersion: 6 } },
+    {
+      code: 'doThing().catch(() => { throw 4 })',
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // random functions and callback methods
     'var x = function() { return Promise.resolve(4) }',
@@ -39,22 +50,64 @@ ruleTester.run('no-nesting', rule, {
     'doThing(function(x) { return Promise.reject(x) })',
 
     // this should be allowed basically, we're mostly raging against using then()
-    {code: 'doThing().then(function() { return Promise.all([a,b,c]) })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(function() { return Promise.resolve(4) })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => Promise.resolve(4))', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => Promise.all([a]))', parserOptions: {ecmaVersion: 6}}
+    {
+      code: 'doThing().then(function() { return Promise.all([a,b,c]) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(function() { return Promise.resolve(4) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => Promise.resolve(4))',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => Promise.all([a]))',
+      parserOptions: { ecmaVersion: 6 }
+    }
   ],
 
   invalid: [
-
-    {code: 'doThing().then(function() { a.then() })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(function() { b.catch() })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(function() { return a.then() })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(function() { return b.catch() })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => { a.then() })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => { b.catch() })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => a.then())', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => b.catch())', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}}
-
+    {
+      code: 'doThing().then(function() { a.then() })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(function() { b.catch() })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(function() { return a.then() })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(function() { return b.catch() })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => { a.then() })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => { b.catch() })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => a.then())',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => b.catch())',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    }
   ]
 })

--- a/test/no-promise-in-callback.js
+++ b/test/no-promise-in-callback.js
@@ -9,49 +9,104 @@ var errorMessage = 'Avoid using promises inside of callbacks.'
 
 ruleTester.run('no-promise-in-callback', rule, {
   valid: [
-
     'go(function() { return Promise.resolve(4) })',
     'go(function() { return a.then(b) })',
     'go(function() { b.catch(c) })',
     'go(function() { b.then(c, d) })',
 
     // arrow functions and other things
-    {code: 'go(() => Promise.resolve(4))', parserOptions: {ecmaVersion: 6}},
-    {code: 'go((errrr) => a.then(b))', parserOptions: {ecmaVersion: 6}},
-    {code: 'go((elpers) => { b.catch(c) })', parserOptions: {ecmaVersion: 6}},
-    {code: 'go((e) => { b.then(c, d) })', parserOptions: {ecmaVersion: 6}},
+    { code: 'go(() => Promise.resolve(4))', parserOptions: { ecmaVersion: 6 } },
+    { code: 'go((errrr) => a.then(b))', parserOptions: { ecmaVersion: 6 } },
+    {
+      code: 'go((elpers) => { b.catch(c) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    { code: 'go((e) => { b.then(c, d) })', parserOptions: { ecmaVersion: 6 } },
 
     // within promises it won't complain
-    {code: 'a.catch((err) => { b.then(c, d) })', parserOptions: {ecmaVersion: 6}},
+    {
+      code: 'a.catch((err) => { b.then(c, d) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // random unrelated things
     'var x = function() { return Promise.resolve(4) }',
     'function y() { return Promise.resolve(4) }',
     'function then() { return Promise.reject() }',
     'doThing(function(x) { return Promise.reject(x) })',
-    {code: 'doThing().then(function() { return Promise.all([a,b,c]) })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(function() { return Promise.resolve(4) })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => Promise.resolve(4))', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => Promise.all([a]))', parserOptions: {ecmaVersion: 6}},
+    {
+      code: 'doThing().then(function() { return Promise.all([a,b,c]) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(function() { return Promise.resolve(4) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => Promise.resolve(4))',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(() => Promise.all([a]))',
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // weird case, we assume it's not a big deal if you return (even though you may be cheating)
-    {code: 'a(function(err) { return doThing().then(a) })', parserOptions: {ecmaVersion: 6}}
-
+    {
+      code: 'a(function(err) { return doThing().then(a) })',
+      parserOptions: { ecmaVersion: 6 }
+    }
   ],
 
   invalid: [
-    {code: 'a(function(err) { doThing().then(a) })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a(function(error, zup, supa) { doThing().then(a) })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a(function(error) { doThing().then(a) })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
+    {
+      code: 'a(function(err) { doThing().then(a) })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a(function(error, zup, supa) { doThing().then(a) })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a(function(error) { doThing().then(a) })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // arrow function
-    {code: 'a((error) => { doThing().then(a) })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a((error) => doThing().then(a))', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a((err, data) => { doThing().then(a) })', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'a((err, data) => doThing().then(a))', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
+    {
+      code: 'a((error) => { doThing().then(a) })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a((error) => doThing().then(a))',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a((err, data) => { doThing().then(a) })',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'a((err, data) => doThing().then(a))',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // function decl. and similar (why not)
-    {code: 'function x(err) { Promise.all() }', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}},
-    {code: 'let x = (err) => doThingWith(err).then(a)', errors: [{message: errorMessage}], parserOptions: {ecmaVersion: 6}}
+    {
+      code: 'function x(err) { Promise.all() }',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'let x = (err) => doThingWith(err).then(a)',
+      errors: [{ message: errorMessage }],
+      parserOptions: { ecmaVersion: 6 }
+    }
   ]
 })

--- a/test/no-return-in-finally.js
+++ b/test/no-return-in-finally.js
@@ -7,16 +7,40 @@ var message = 'No return in finally'
 
 ruleTester.run('no-return-in-finally', rule, {
   valid: [
-    { code: 'Promise.resolve(1).finally(() => { console.log(2) })', parserOptions: { ecmaVersion: 6 } },
-    { code: 'Promise.reject(4).finally(() => { console.log(2) })', parserOptions: { ecmaVersion: 6 } },
-    { code: 'Promise.reject(4).finally(() => {})', parserOptions: { ecmaVersion: 6 } },
+    {
+      code: 'Promise.resolve(1).finally(() => { console.log(2) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'Promise.reject(4).finally(() => { console.log(2) })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'Promise.reject(4).finally(() => {})',
+      parserOptions: { ecmaVersion: 6 }
+    },
     { code: 'myPromise.finally(() => {});', parserOptions: { ecmaVersion: 6 } },
     { code: 'Promise.resolve(1).finally(function () { })' }
   ],
   invalid: [
-    { code: 'Promise.resolve(1).finally(() => { return 2 })', parserOptions: { ecmaVersion: 6 }, errors: [ { message: message } ] },
-    { code: 'Promise.reject(0).finally(() => { return 2 })', parserOptions: { ecmaVersion: 6 }, errors: [ { message: message } ] },
-    { code: 'myPromise.finally(() => { return 2 });', parserOptions: { ecmaVersion: 6 }, errors: [ { message: message } ] },
-    { code: 'Promise.resolve(1).finally(function () { return 2 })', errors: [ { message: message } ] }
+    {
+      code: 'Promise.resolve(1).finally(() => { return 2 })',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{ message: message }]
+    },
+    {
+      code: 'Promise.reject(0).finally(() => { return 2 })',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{ message: message }]
+    },
+    {
+      code: 'myPromise.finally(() => { return 2 });',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{ message: message }]
+    },
+    {
+      code: 'Promise.resolve(1).finally(function () { return 2 })',
+      errors: [{ message: message }]
+    }
   ]
 })

--- a/test/no-return-wrap.js
+++ b/test/no-return-wrap.js
@@ -10,7 +10,6 @@ var resolveMessage = 'Avoid wrapping return values in Promise.resolve'
 
 ruleTester.run('no-return-wrap', rule, {
   valid: [
-
     // resolve and reject are sometimes okay
     'Promise.resolve(4).then(function(x) { return x })',
     'Promise.reject(4).then(function(x) { return x })',
@@ -29,12 +28,24 @@ ruleTester.run('no-return-wrap', rule, {
     'doThing().then(function() { return Promise.all([a,b,c]) })',
 
     // arrow functions and other things
-    {code: 'doThing().then(() => 4)', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(() => { throw 4 })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(()=>{}, () => 4)', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().then(()=>{}, () => { throw 4 })', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().catch(() => 4)', parserOptions: {ecmaVersion: 6}},
-    {code: 'doThing().catch(() => { throw 4 })', parserOptions: {ecmaVersion: 6}},
+    { code: 'doThing().then(() => 4)', parserOptions: { ecmaVersion: 6 } },
+    {
+      code: 'doThing().then(() => { throw 4 })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(()=>{}, () => 4)',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: 'doThing().then(()=>{}, () => { throw 4 })',
+      parserOptions: { ecmaVersion: 6 }
+    },
+    { code: 'doThing().catch(() => 4)', parserOptions: { ecmaVersion: 6 } },
+    {
+      code: 'doThing().catch(() => { throw 4 })',
+      parserOptions: { ecmaVersion: 6 }
+    },
 
     // random functions and callback methods
     'var x = function() { return Promise.resolve(4) }',
@@ -46,39 +57,68 @@ ruleTester.run('no-return-wrap', rule, {
     'doThing().then(function() { return })',
 
     // allow reject if specified
-    {code: 'doThing().then(function() { return Promise.reject(4) })', options: [{allowReject: true}]}
+    {
+      code: 'doThing().then(function() { return Promise.reject(4) })',
+      options: [{ allowReject: true }]
+    }
   ],
 
   invalid: [
-
     // wrapped resolve is bad
-    {code: 'doThing().then(function() { return Promise.resolve(4) })', errors: [{message: resolveMessage}]},
-    {code: 'doThing().then(null, function() { return Promise.resolve(4) })', errors: [{message: resolveMessage}]},
-    {code: 'doThing().catch(function() { return Promise.resolve(4) })', errors: [{message: resolveMessage}]},
+    {
+      code: 'doThing().then(function() { return Promise.resolve(4) })',
+      errors: [{ message: resolveMessage }]
+    },
+    {
+      code: 'doThing().then(null, function() { return Promise.resolve(4) })',
+      errors: [{ message: resolveMessage }]
+    },
+    {
+      code: 'doThing().catch(function() { return Promise.resolve(4) })',
+      errors: [{ message: resolveMessage }]
+    },
 
     // wrapped reject is bad
-    {code: 'doThing().then(function() { return Promise.reject(4) })', errors: [{message: rejectMessage}]},
-    {code: 'doThing().then(null, function() { return Promise.reject(4) })', errors: [{message: rejectMessage}]},
-    {code: 'doThing().catch(function() { return Promise.reject(4) })', errors: [{message: rejectMessage}]},
+    {
+      code: 'doThing().then(function() { return Promise.reject(4) })',
+      errors: [{ message: rejectMessage }]
+    },
+    {
+      code: 'doThing().then(null, function() { return Promise.reject(4) })',
+      errors: [{ message: rejectMessage }]
+    },
+    {
+      code: 'doThing().catch(function() { return Promise.reject(4) })',
+      errors: [{ message: rejectMessage }]
+    },
 
     // needs to also look at weird paths
     {
-      code: 'doThing().then(function(x) { if (x>1) { return Promise.resolve(4) } else { throw "bad" } })',
-      errors: [{message: resolveMessage}]
+      code:
+        'doThing().then(function(x) { if (x>1) { return Promise.resolve(4) } else { throw "bad" } })',
+      errors: [{ message: resolveMessage }]
     },
-    {code: 'doThing().then(function(x) { if (x>1) { return Promise.reject(4) } })', errors: [{message: rejectMessage}]},
     {
-      code: 'doThing().then(null, function() { if (true && false) { return Promise.resolve() } })',
-      errors: [{message: resolveMessage}]
+      code:
+        'doThing().then(function(x) { if (x>1) { return Promise.reject(4) } })',
+      errors: [{ message: rejectMessage }]
+    },
+    {
+      code:
+        'doThing().then(null, function() { if (true && false) { return Promise.resolve() } })',
+      errors: [{ message: resolveMessage }]
     },
 
     // should do both
-    {code: 'doThing().catch(function(x) {if (x) { return Promise.resolve(4) } else { return Promise.reject() } })', errors: [{message: resolveMessage}, {message: rejectMessage}]}
+    {
+      code:
+        'doThing().catch(function(x) {if (x) { return Promise.resolve(4) } else { return Promise.reject() } })',
+      errors: [{ message: resolveMessage }, { message: rejectMessage }]
+    }
 
     // should work someday
     // {code: 'doThing().catch(function(x) { return x && Promise.resolve(4) })', errors: [{message: resolveMessage}]},
     // {code: 'doThing().catch(function(x) { return true ? Promise.resolve(4) : Promise.reject(5) })', errors: [{message: rejectMessage }, {message: resolveMessage}]},
     // {code: 'doThing().catch(function(x) { return x && Promise.reject(4) })', errors: [{message: rejectMessage}]}
-
   ]
 })

--- a/test/param-names.test.js
+++ b/test/param-names.test.js
@@ -13,11 +13,21 @@ ruleTester.run('param-names', rule, {
   invalid: [
     {
       code: 'new Promise(function(reject, resolve) { })',
-      errors: [ { message: 'Promise constructor parameters must be named resolve, reject' } ]
+      errors: [
+        {
+          message:
+            'Promise constructor parameters must be named resolve, reject'
+        }
+      ]
     },
     {
       code: 'new Promise(function(resolve, rej) { })',
-      errors: [ { message: 'Promise constructor parameters must be named resolve, reject' } ]
+      errors: [
+        {
+          message:
+            'Promise constructor parameters must be named resolve, reject'
+        }
+      ]
     }
   ]
 })

--- a/test/prefer-await-to-callbacks.js
+++ b/test/prefer-await-to-callbacks.js
@@ -8,51 +8,61 @@ var ruleTester = new RuleTester()
 
 ruleTester.run('prefer-await-to-callbacks', rule, {
   valid: [
-    { code: 'async function hi() { await thing().catch(err => console.log(err)) }', parserOptions: parserOptions },
-    { code: 'async function hi() { await thing().then() }', parserOptions: parserOptions },
-    { code: 'async function hi() { await thing().catch() }', parserOptions: parserOptions }
+    {
+      code:
+        'async function hi() { await thing().catch(err => console.log(err)) }',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'async function hi() { await thing().then() }',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'async function hi() { await thing().catch() }',
+      parserOptions: parserOptions
+    }
   ],
 
   invalid: [
     {
       code: 'heart(function(err) {})',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'heart(err => {})',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'heart("ball", function(err) {})',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'function getData(id, callback) {}',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'const getData = (cb) => {}',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'var x = function (x, cb) {}',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'cb()',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'callback()',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     }
   ]
 })

--- a/test/prefer-await-to-then.js
+++ b/test/prefer-await-to-then.js
@@ -7,31 +7,41 @@ var parserOptions = { ecmaVersion: 8 }
 var ruleTester = new RuleTester()
 ruleTester.run('prefer-await-to-then', rule, {
   valid: [
-    { code: 'async function hi() { await thing() }', parserOptions: parserOptions },
-    { code: 'async function hi() { await thing().then() }', parserOptions: parserOptions },
-    { code: 'async function hi() { await thing().catch() }', parserOptions: parserOptions }
+    {
+      code: 'async function hi() { await thing() }',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'async function hi() { await thing().then() }',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'async function hi() { await thing().catch() }',
+      parserOptions: parserOptions
+    }
   ],
 
   invalid: [
     {
       code: 'hey.then(x => {})',
       parserOptions: parserOptions,
-      errors: [ { message: message } ]
+      errors: [{ message: message }]
     },
     {
       code: 'hey.then(function() { }).then()',
       parserOptions: parserOptions,
-      errors: [ { message: message }, { message: message } ]
+      errors: [{ message: message }, { message: message }]
     },
     {
       code: 'hey.then(function() { }).then(x).catch()',
       parserOptions: parserOptions,
-      errors: [ { message: message }, { message: message } ]
+      errors: [{ message: message }, { message: message }]
     },
     {
-      code: 'async function a() { hey.then(function() { }).then(function() { }) }',
+      code:
+        'async function a() { hey.then(function() { }).then(function() { }) }',
       parserOptions: parserOptions,
-      errors: [ { message: message }, { message: message } ]
+      errors: [{ message: message }, { message: message }]
     }
   ]
 })


### PR DESCRIPTION
Resolves #95

This PR updates this codebases' code formatting tools to look like this:

* [Prettier](https://prettier.io/) is used for code formatting
* ESLint is used for code linting

The ESLint configuration is based on [`eslint-config-standard`](https://github.com/standard/eslint-config-standard), so we continue to use the configuration of Standard, but it also includes [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) in order to turn off all stylistic lint rules that may conflict with Prettier. I think this is a nice compromise.

Also included in this PR is [lint-staged](https://github.com/okonet/lint-staged), which will execute the following commands on staged files during a precommit hook:

* when the README is staged, runs [doctoc](https://github.com/thlorenz/doctoc) in order to keep the table of contents up-to-date
* when a `.js` file is staged, runs Prettier to format the file and runs `eslint --fix` to lint the file
* when a `.json` file is staged, runs Prettier to format the file

Since the ESLint configuration has been updated to include the Prettier configuration, I have reformatted all `.js` and `.json` files by running `prettier --write **/*.+(js|json)`. 

This PR touches a lot of files, but all tests continue to pass, so I'm 👍  on bringing this change in. I'm going to leave it open for a little bit and think about it. @xjamundx if you have thoughts on if this is a 👍  / 👎  change, please let me know.