### PR TITLE
refactor: clean up tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
         "pattern": "https://github.com/xjamundx/eslint-plugin-promise#{{name}}"
       }
     ],
+    "eslint-plugin/test-case-shorthand-strings": "error",
     "prettier/prettier": "error"
   }
 }

--- a/test/always-return.test.js
+++ b/test/always-return.test.js
@@ -1,151 +1,98 @@
 'use strict'
 
-var rule = require('../rules/always-return')
-var RuleTester = require('eslint').RuleTester
-var message = 'Each then() should return a value or throw'
-var parserOptions = { ecmaVersion: 6 }
-var ruleTester = new RuleTester()
+const rule = require('../rules/always-return')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
+
+const message = 'Each then() should return a value or throw'
+
 ruleTester.run('always-return', rule, {
   valid: [
-    { code: 'hey.then(x => x)', parserOptions: parserOptions },
-    { code: 'hey.then(x => ({}))', parserOptions: parserOptions },
-    { code: 'hey.then(x => { return; })', parserOptions: parserOptions },
-    {
-      code: 'hey.then(x => { return x ? x.id : null })',
-      parserOptions: parserOptions
-    },
-    { code: 'hey.then(x => { return x * 10 })', parserOptions: parserOptions },
-    {
-      code: 'hey.then(function() { return 42; })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(function() { return new Promise(); })',
-      parserOptions: parserOptions
-    },
-    { code: 'hey.then(function() { return "x"; }).then(doSomethingWicked)' },
-    {
-      code: 'hey.then(x => x).then(function() { return "3" })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(function() { throw new Error("msg"); })',
-      parserOptions: parserOptions
-    },
-    {
-      code:
-        'hey.then(function(x) { if (!x) { throw new Error("no x"); } return x; })',
-      parserOptions: parserOptions
-    },
-    {
-      code:
-        'hey.then(function(x) { if (x) { return x; } throw new Error("no x"); })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { throw new Error("msg"); })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { if (!x) { throw new Error("no x"); } return x; })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { if (x) { return x; } throw new Error("no x"); })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { var f = function() { }; return f; })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { if (x) { return x; } else { return x; } })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { return x; var y = "unreachable"; })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { return x; return "unreachable"; })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { return; }, err=>{ log(err); })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { return x && x(); }, err=>{ log(err); })',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'hey.then(x => { return x.y || x(); }, err=>{ log(err); })',
-      parserOptions: parserOptions
-    },
-    {
-      code: `hey.then(x => {
+    'hey.then(x => x)',
+    'hey.then(x => ({}))',
+    'hey.then(x => { return; })',
+    'hey.then(x => { return x ? x.id : null })',
+    'hey.then(x => { return x * 10 })',
+    'hey.then(function() { return 42; })',
+    'hey.then(function() { return new Promise(); })',
+    'hey.then(function() { return "x"; }).then(doSomethingWicked)',
+    'hey.then(x => x).then(function() { return "3" })',
+    'hey.then(function() { throw new Error("msg"); })',
+    'hey.then(function(x) { if (!x) { throw new Error("no x"); } return x; })',
+    'hey.then(function(x) { if (x) { return x; } throw new Error("no x"); })',
+    'hey.then(x => { throw new Error("msg"); })',
+    'hey.then(x => { if (!x) { throw new Error("no x"); } return x; })',
+    'hey.then(x => { if (x) { return x; } throw new Error("no x"); })',
+    'hey.then(x => { var f = function() { }; return f; })',
+    'hey.then(x => { if (x) { return x; } else { return x; } })',
+    'hey.then(x => { return x; var y = "unreachable"; })',
+    'hey.then(x => { return x; return "unreachable"; })',
+    'hey.then(x => { return; }, err=>{ log(err); })',
+    'hey.then(x => { return x && x(); }, err=>{ log(err); })',
+    'hey.then(x => { return x.y || x(); }, err=>{ log(err); })',
+    `hey.then(x => {
         return anotherFunc({
           nested: {
             one: x === 1 ? 1 : 0,
             two: x === 2 ? 1 : 0
           }
         })
-      })`,
-      parserOptions: parserOptions
-    }
+      })`
   ],
 
   invalid: [
     {
       code: 'hey.then(x => {})',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { })',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { }).then(x)',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { }).then(function() { })',
-      errors: [{ message: message }, { message: message }]
+      errors: [{ message }, { message }]
     },
     {
       code: 'hey.then(function() { return; }).then(function() { })',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { doSomethingWicked(); })',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { if (x) { return x; } })',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { if (x) { return x; } else { }})',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { if (x) { } else { return x; }})',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code:
         'hey.then(function() { if (x) { return you.then(function() { return x; }); } })',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then( x => { x ? x.id : null })',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function(x) { x ? x.id : null })',
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: `(function() {
@@ -158,8 +105,7 @@ ruleTester.run('always-return', rule, {
           })
         })
       })()`,
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     }
   ]
 })

--- a/test/avoid-new.js
+++ b/test/avoid-new.js
@@ -1,11 +1,14 @@
 'use strict'
 
-var rule = require('../rules/avoid-new')
-var RuleTester = require('eslint').RuleTester
-var ruleTester = new RuleTester()
+const rule = require('../rules/avoid-new')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
 
-// messages
-var errorMessage = 'Avoid creating new promises.'
+const errorMessage = 'Avoid creating new promises.'
 
 ruleTester.run('avoid-new', rule, {
   valid: [
@@ -20,18 +23,15 @@ ruleTester.run('avoid-new', rule, {
   invalid: [
     {
       code: 'var x = new Promise(function (x, y) {})',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'new Promise()',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'Thing(new Promise(() => {}))',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     }
   ]
 })

--- a/test/catch-or-return.test.js
+++ b/test/catch-or-return.test.js
@@ -1,9 +1,12 @@
 'use strict'
 
-var rule = require('../rules/catch-or-return')
-var RuleTester = require('eslint').RuleTester
-var message = 'Expected catch() or return'
-var ruleTester = new RuleTester()
+const rule = require('../rules/catch-or-return')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester()
+
+const catchMessage = 'Expected catch() or return'
+const doneMessage = 'Expected done() or return'
+
 ruleTester.run('catch-or-return', rule, {
   valid: [
     // catch
@@ -111,53 +114,53 @@ ruleTester.run('catch-or-return', rule, {
     // catch failures
     {
       code: 'function callPromise(promise, cb) { promise.then(cb) }',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
     {
       code: 'fetch("http://www.yahoo.com").then(console.log.bind(console))',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
     {
       code: 'a.then(function() { return "x"; }).then(function(y) { throw y; })',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
     {
       code: 'Promise.resolve(frank)',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
     {
       code: 'frank.then(to).finally(fn)',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
 
     // return failures
     {
       code: 'function a() { frank().then(go) }',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
     {
       code: 'function a() { frank().then(go).then().then().then() }',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
     {
       code: 'function a() { frank().then(go).then()}',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
     {
       code: 'function a() { frank.then(go).then(to) }',
-      errors: [{ message: message }]
+      errors: [{ message: catchMessage }]
     },
 
     // terminationMethod=done - .done(null, fn)
     {
       code: 'frank().then(go)',
       options: [{ terminationMethod: 'done' }],
-      errors: [{ message: 'Expected done() or return' }]
+      errors: [{ message: doneMessage }]
     },
     {
       code: 'frank().catch(go)',
       options: [{ terminationMethod: 'done' }],
-      errors: [{ message: 'Expected done() or return' }]
+      errors: [{ message: doneMessage }]
     }
   ]
 })

--- a/test/no-callback-in-promise.js
+++ b/test/no-callback-in-promise.js
@@ -1,11 +1,14 @@
 'use strict'
 
-var rule = require('../rules/no-callback-in-promise')
-var RuleTester = require('eslint').RuleTester
-var ruleTester = new RuleTester()
+const rule = require('../rules/no-callback-in-promise')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
 
-// messages
-var errorMessage = 'Avoid calling back inside of a promise.'
+const errorMessage = 'Avoid calling back inside of a promise.'
 
 ruleTester.run('no-callback-in-promise', rule, {
   valid: [
@@ -15,13 +18,12 @@ ruleTester.run('no-callback-in-promise', rule, {
     'doSomething(function(err) { callback(err) })',
 
     // arrow functions and other things
-    { code: 'let thing = (cb) => cb()', parserOptions: { ecmaVersion: 6 } },
-    { code: 'doSomething(err => cb(err))', parserOptions: { ecmaVersion: 6 } },
+    'let thing = (cb) => cb()',
+    'doSomething(err => cb(err))',
 
     // exceptions test
     {
       code: 'a.then(() => next())',
-      parserOptions: { ecmaVersion: 6 },
       options: [{ exceptions: ['next'] }]
     }
   ],
@@ -29,62 +31,49 @@ ruleTester.run('no-callback-in-promise', rule, {
   invalid: [
     {
       code: 'a.then(cb)',
-      errors: [{ message: errorMessage, column: 8 }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage, column: 8 }]
     },
     {
       code: 'a.then(() => cb())',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'a.then(function(err) { cb(err) })',
-      errors: [{ message: errorMessage, column: 24 }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage, column: 24 }]
     },
     {
       code: 'a.then(function(data) { cb(data) }, function(err) { cb(err) })',
       errors: [
         { column: 25, message: errorMessage },
         { column: 53, message: errorMessage }
-      ],
-      parserOptions: { ecmaVersion: 6 }
+      ]
     },
     {
       code: 'a.catch(function(err) { cb(err) })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
 
     // callback should also complain
     {
       code: 'a.then(callback)',
-      errors: [{ message: errorMessage, column: 8 }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage, column: 8 }]
     },
     {
       code: 'a.then(() => callback())',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'a.then(function(err) { callback(err) })',
-      errors: [{ message: errorMessage, column: 24 }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage, column: 24 }]
     },
     {
       code:
         'a.then(function(data) { callback(data) }, function(err) { callback(err) })',
-      errors: [
-        { message: errorMessage },
-        { column: 59, message: errorMessage }
-      ],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }, { column: 59, message: errorMessage }]
     },
     {
       code: 'a.catch(function(err) { callback(err) })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     }
   ]
 })

--- a/test/no-native.js
+++ b/test/no-native.js
@@ -1,27 +1,19 @@
 'use strict'
 
-var rule = require('../rules/no-native')
-var RuleTester = require('eslint').RuleTester
-var parserOptions = { sourceType: 'module', ecmaVersion: 6 }
-var ruleTester = new RuleTester()
+const rule = require('../rules/no-native')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  }
+})
+
 ruleTester.run('no-native', rule, {
   valid: [
     'var Promise = null; function x() { return Promise.resolve("hi"); }',
     'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();',
-    {
-      code:
-        'var Promise = null; function x() { return Promise.resolve("hi"); }',
-      parserOptions: parserOptions
-    },
-    {
-      code:
-        'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'import Promise from "bluebird"; var x = Promise.reject();',
-      parserOptions: parserOptions
-    }
+    'import Promise from "bluebird"; var x = Promise.reject();'
   ],
 
   invalid: [

--- a/test/no-nesting.js
+++ b/test/no-nesting.js
@@ -1,11 +1,14 @@
 'use strict'
 
-var rule = require('../rules/no-nesting')
-var RuleTester = require('eslint').RuleTester
-var ruleTester = new RuleTester()
+const rule = require('../rules/no-nesting')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
 
-// messages
-var errorMessage = 'Avoid nesting promises.'
+const errorMessage = 'Avoid nesting promises.'
 
 ruleTester.run('no-nesting', rule, {
   valid: [
@@ -24,24 +27,12 @@ ruleTester.run('no-nesting', rule, {
     'doThing().catch(null, function() { throw 4 })',
 
     // arrow functions and other things
-    { code: 'doThing().then(() => 4)', parserOptions: { ecmaVersion: 6 } },
-    {
-      code: 'doThing().then(() => { throw 4 })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(()=>{}, () => 4)',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(()=>{}, () => { throw 4 })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    { code: 'doThing().catch(() => 4)', parserOptions: { ecmaVersion: 6 } },
-    {
-      code: 'doThing().catch(() => { throw 4 })',
-      parserOptions: { ecmaVersion: 6 }
-    },
+    'doThing().then(() => 4)',
+    'doThing().then(() => { throw 4 })',
+    'doThing().then(()=>{}, () => 4)',
+    'doThing().then(()=>{}, () => { throw 4 })',
+    'doThing().catch(() => 4)',
+    'doThing().catch(() => { throw 4 })',
 
     // random functions and callback methods
     'var x = function() { return Promise.resolve(4) }',
@@ -50,64 +41,44 @@ ruleTester.run('no-nesting', rule, {
     'doThing(function(x) { return Promise.reject(x) })',
 
     // this should be allowed basically, we're mostly raging against using then()
-    {
-      code: 'doThing().then(function() { return Promise.all([a,b,c]) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(function() { return Promise.resolve(4) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(() => Promise.resolve(4))',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(() => Promise.all([a]))',
-      parserOptions: { ecmaVersion: 6 }
-    }
+    'doThing().then(function() { return Promise.all([a,b,c]) })',
+    'doThing().then(function() { return Promise.resolve(4) })',
+    'doThing().then(() => Promise.resolve(4))',
+    'doThing().then(() => Promise.all([a]))'
   ],
 
   invalid: [
     {
       code: 'doThing().then(function() { a.then() })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'doThing().then(function() { b.catch() })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'doThing().then(function() { return a.then() })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'doThing().then(function() { return b.catch() })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'doThing().then(() => { a.then() })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'doThing().then(() => { b.catch() })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'doThing().then(() => a.then())',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'doThing().then(() => b.catch())',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     }
   ]
 })

--- a/test/no-promise-in-callback.js
+++ b/test/no-promise-in-callback.js
@@ -1,11 +1,14 @@
 'use strict'
 
-var rule = require('../rules/no-promise-in-callback')
-var RuleTester = require('eslint').RuleTester
-var ruleTester = new RuleTester()
+const rule = require('../rules/no-promise-in-callback')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
 
-// messages
-var errorMessage = 'Avoid using promises inside of callbacks.'
+const errorMessage = 'Avoid using promises inside of callbacks.'
 
 ruleTester.run('no-promise-in-callback', rule, {
   valid: [
@@ -15,98 +18,68 @@ ruleTester.run('no-promise-in-callback', rule, {
     'go(function() { b.then(c, d) })',
 
     // arrow functions and other things
-    { code: 'go(() => Promise.resolve(4))', parserOptions: { ecmaVersion: 6 } },
-    { code: 'go((errrr) => a.then(b))', parserOptions: { ecmaVersion: 6 } },
-    {
-      code: 'go((elpers) => { b.catch(c) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    { code: 'go((e) => { b.then(c, d) })', parserOptions: { ecmaVersion: 6 } },
+    'go(() => Promise.resolve(4))',
+    'go((errrr) => a.then(b))',
+    'go((elpers) => { b.catch(c) })',
+    'go((e) => { b.then(c, d) })',
 
     // within promises it won't complain
-    {
-      code: 'a.catch((err) => { b.then(c, d) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
+    'a.catch((err) => { b.then(c, d) })',
 
     // random unrelated things
     'var x = function() { return Promise.resolve(4) }',
     'function y() { return Promise.resolve(4) }',
     'function then() { return Promise.reject() }',
     'doThing(function(x) { return Promise.reject(x) })',
-    {
-      code: 'doThing().then(function() { return Promise.all([a,b,c]) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(function() { return Promise.resolve(4) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(() => Promise.resolve(4))',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(() => Promise.all([a]))',
-      parserOptions: { ecmaVersion: 6 }
-    },
+    'doThing().then(function() { return Promise.all([a,b,c]) })',
+    'doThing().then(function() { return Promise.resolve(4) })',
+    'doThing().then(() => Promise.resolve(4))',
+    'doThing().then(() => Promise.all([a]))',
 
     // weird case, we assume it's not a big deal if you return (even though you may be cheating)
-    {
-      code: 'a(function(err) { return doThing().then(a) })',
-      parserOptions: { ecmaVersion: 6 }
-    }
+    'a(function(err) { return doThing().then(a) })'
   ],
 
   invalid: [
     {
       code: 'a(function(err) { doThing().then(a) })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'a(function(error, zup, supa) { doThing().then(a) })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'a(function(error) { doThing().then(a) })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
 
     // arrow function
     {
       code: 'a((error) => { doThing().then(a) })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'a((error) => doThing().then(a))',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'a((err, data) => { doThing().then(a) })',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'a((err, data) => doThing().then(a))',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
 
     // function decl. and similar (why not)
     {
       code: 'function x(err) { Promise.all() }',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     },
     {
       code: 'let x = (err) => doThingWith(err).then(a)',
-      errors: [{ message: errorMessage }],
-      parserOptions: { ecmaVersion: 6 }
+      errors: [{ message: errorMessage }]
     }
   ]
 })

--- a/test/no-return-in-finally.js
+++ b/test/no-return-in-finally.js
@@ -1,46 +1,39 @@
 'use strict'
 
-var RuleTester = require('eslint').RuleTester
-var rule = require('../rules/no-return-in-finally')
-var ruleTester = new RuleTester()
-var message = 'No return in finally'
+const RuleTester = require('eslint').RuleTester
+const rule = require('../rules/no-return-in-finally')
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
+
+const message = 'No return in finally'
 
 ruleTester.run('no-return-in-finally', rule, {
   valid: [
-    {
-      code: 'Promise.resolve(1).finally(() => { console.log(2) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'Promise.reject(4).finally(() => { console.log(2) })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'Promise.reject(4).finally(() => {})',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    { code: 'myPromise.finally(() => {});', parserOptions: { ecmaVersion: 6 } },
-    { code: 'Promise.resolve(1).finally(function () { })' }
+    'Promise.resolve(1).finally(() => { console.log(2) })',
+    'Promise.reject(4).finally(() => { console.log(2) })',
+    'Promise.reject(4).finally(() => {})',
+    'myPromise.finally(() => {});',
+    'Promise.resolve(1).finally(function () { })'
   ],
   invalid: [
     {
       code: 'Promise.resolve(1).finally(() => { return 2 })',
-      parserOptions: { ecmaVersion: 6 },
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'Promise.reject(0).finally(() => { return 2 })',
-      parserOptions: { ecmaVersion: 6 },
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'myPromise.finally(() => { return 2 });',
-      parserOptions: { ecmaVersion: 6 },
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'Promise.resolve(1).finally(function () { return 2 })',
-      errors: [{ message: message }]
+      errors: [{ message }]
     }
   ]
 })

--- a/test/no-return-wrap.js
+++ b/test/no-return-wrap.js
@@ -1,12 +1,15 @@
 'use strict'
 
-var rule = require('../rules/no-return-wrap')
-var RuleTester = require('eslint').RuleTester
-var ruleTester = new RuleTester()
+const rule = require('../rules/no-return-wrap')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
 
-// messages
-var rejectMessage = 'Expected throw instead of Promise.reject'
-var resolveMessage = 'Avoid wrapping return values in Promise.resolve'
+const rejectMessage = 'Expected throw instead of Promise.reject'
+const resolveMessage = 'Avoid wrapping return values in Promise.resolve'
 
 ruleTester.run('no-return-wrap', rule, {
   valid: [
@@ -28,24 +31,12 @@ ruleTester.run('no-return-wrap', rule, {
     'doThing().then(function() { return Promise.all([a,b,c]) })',
 
     // arrow functions and other things
-    { code: 'doThing().then(() => 4)', parserOptions: { ecmaVersion: 6 } },
-    {
-      code: 'doThing().then(() => { throw 4 })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(()=>{}, () => 4)',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    {
-      code: 'doThing().then(()=>{}, () => { throw 4 })',
-      parserOptions: { ecmaVersion: 6 }
-    },
-    { code: 'doThing().catch(() => 4)', parserOptions: { ecmaVersion: 6 } },
-    {
-      code: 'doThing().catch(() => { throw 4 })',
-      parserOptions: { ecmaVersion: 6 }
-    },
+    'doThing().then(() => 4)',
+    'doThing().then(() => { throw 4 })',
+    'doThing().then(()=>{}, () => 4)',
+    'doThing().then(()=>{}, () => { throw 4 })',
+    'doThing().catch(() => 4)',
+    'doThing().catch(() => { throw 4 })',
 
     // random functions and callback methods
     'var x = function() { return Promise.resolve(4) }',

--- a/test/param-names.test.js
+++ b/test/param-names.test.js
@@ -1,9 +1,11 @@
 'use strict'
 
-var rule = require('../rules/param-names')
-var RuleTester = require('eslint').RuleTester
+const rule = require('../rules/param-names')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester()
 
-var ruleTester = new RuleTester()
+const message = 'Promise constructor parameters must be named resolve, reject'
+
 ruleTester.run('param-names', rule, {
   valid: [
     'new Promise(function(resolve, reject) { })',
@@ -13,21 +15,11 @@ ruleTester.run('param-names', rule, {
   invalid: [
     {
       code: 'new Promise(function(reject, resolve) { })',
-      errors: [
-        {
-          message:
-            'Promise constructor parameters must be named resolve, reject'
-        }
-      ]
+      errors: [{ message }]
     },
     {
       code: 'new Promise(function(resolve, rej) { })',
-      errors: [
-        {
-          message:
-            'Promise constructor parameters must be named resolve, reject'
-        }
-      ]
+      errors: [{ message }]
     }
   ]
 })

--- a/test/prefer-await-to-callbacks.js
+++ b/test/prefer-await-to-callbacks.js
@@ -1,68 +1,54 @@
 'use strict'
 
-var rule = require('../rules/prefer-await-to-callbacks')
-var RuleTester = require('eslint').RuleTester
-var message = 'Avoid callbacks. Prefer Async/Await.'
-var parserOptions = { ecmaVersion: 8 }
-var ruleTester = new RuleTester()
+const rule = require('../rules/prefer-await-to-callbacks')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8
+  }
+})
+
+const message = 'Avoid callbacks. Prefer Async/Await.'
 
 ruleTester.run('prefer-await-to-callbacks', rule, {
   valid: [
-    {
-      code:
-        'async function hi() { await thing().catch(err => console.log(err)) }',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'async function hi() { await thing().then() }',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'async function hi() { await thing().catch() }',
-      parserOptions: parserOptions
-    }
+    'async function hi() { await thing().catch(err => console.log(err)) }',
+    'async function hi() { await thing().then() }',
+    'async function hi() { await thing().catch() }'
   ],
 
   invalid: [
     {
       code: 'heart(function(err) {})',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'heart(err => {})',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'heart("ball", function(err) {})',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'function getData(id, callback) {}',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'const getData = (cb) => {}',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'var x = function (x, cb) {}',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'cb()',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'callback()',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     }
   ]
 })

--- a/test/prefer-await-to-then.js
+++ b/test/prefer-await-to-then.js
@@ -1,47 +1,39 @@
 'use strict'
 
-var rule = require('../rules/prefer-await-to-then')
-var RuleTester = require('eslint').RuleTester
-var message = 'Prefer await to then().'
-var parserOptions = { ecmaVersion: 8 }
-var ruleTester = new RuleTester()
+const rule = require('../rules/prefer-await-to-then')
+const RuleTester = require('eslint').RuleTester
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8
+  }
+})
+
+const message = 'Prefer await to then().'
+
 ruleTester.run('prefer-await-to-then', rule, {
   valid: [
-    {
-      code: 'async function hi() { await thing() }',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'async function hi() { await thing().then() }',
-      parserOptions: parserOptions
-    },
-    {
-      code: 'async function hi() { await thing().catch() }',
-      parserOptions: parserOptions
-    }
+    'async function hi() { await thing() }',
+    'async function hi() { await thing().then() }',
+    'async function hi() { await thing().catch() }'
   ],
 
   invalid: [
     {
       code: 'hey.then(x => {})',
-      parserOptions: parserOptions,
-      errors: [{ message: message }]
+      errors: [{ message }]
     },
     {
       code: 'hey.then(function() { }).then()',
-      parserOptions: parserOptions,
-      errors: [{ message: message }, { message: message }]
+      errors: [{ message }, { message }]
     },
     {
       code: 'hey.then(function() { }).then(x).catch()',
-      parserOptions: parserOptions,
-      errors: [{ message: message }, { message: message }]
+      errors: [{ message }, { message }]
     },
     {
       code:
         'async function a() { hey.then(function() { }).then(function() { }) }',
-      parserOptions: parserOptions,
-      errors: [{ message: message }, { message: message }]
+      errors: [{ message }, { message }]
     }
   ]
 })


### PR DESCRIPTION
This commit refactors the tests in the following way:

* change `var` to `const` where possible
* move most of the `parserOptions` that were declared for each test into the `RuleTester` constructor, which allows for simplifying most of the valid test cases from objects to strings (helped by enabling [`eslint-plugin/test-case-shorthand-strings`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/test-case-shorthand-strings.md)
* clean up message variable names, and when possible, prefer [object shorthand notation](https://eslint.org/docs/rules/object-shorthand)

All tests should continue to pass.