### PR TITLE
style: enable prefer-const rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,8 @@
     "plugin:prettier/recommended"
   ],
   "rules": {
+    "no-var": "error",
+    "prefer-const": "error",
     "strict": ["error", "global"],
     "eslint-plugin/require-meta-docs-url": [
       "error",

--- a/rules/always-return.js
+++ b/rules/always-return.js
@@ -88,11 +88,11 @@ module.exports = {
     //          s2_4:
     //           { good: false,
     //             loc: <loc> } } } ]
-    var funcInfoStack = []
+    const funcInfoStack = []
 
     function markCurrentBranchAsGood() {
-      var funcInfo = peek(funcInfoStack)
-      var currentBranchID = peek(funcInfo.branchIDStack)
+      const funcInfo = peek(funcInfoStack)
+      const currentBranchID = peek(funcInfo.branchIDStack)
       if (funcInfo.branchInfoMap[currentBranchID]) {
         funcInfo.branchInfoMap[currentBranchID].good = true
       }
@@ -104,13 +104,13 @@ module.exports = {
       ThrowStatement: markCurrentBranchAsGood,
 
       onCodePathSegmentStart: function(segment, node) {
-        var funcInfo = peek(funcInfoStack)
+        const funcInfo = peek(funcInfoStack)
         funcInfo.branchIDStack.push(segment.id)
         funcInfo.branchInfoMap[segment.id] = { good: false, node: node }
       },
 
       onCodePathSegmentEnd: function(segment, node) {
-        var funcInfo = peek(funcInfoStack)
+        const funcInfo = peek(funcInfoStack)
         funcInfo.branchIDStack.pop()
       },
 
@@ -122,24 +122,24 @@ module.exports = {
       },
 
       onCodePathEnd: function(path, node) {
-        var funcInfo = funcInfoStack.pop()
+        const funcInfo = funcInfoStack.pop()
 
         if (!isInlineThenFunctionExpression(node)) {
           return
         }
 
         path.finalSegments.forEach(segment => {
-          var id = segment.id
-          var branch = funcInfo.branchInfoMap[id]
+          const id = segment.id
+          const branch = funcInfo.branchInfoMap[id]
           if (!branch.good) {
             if (hasParentReturnStatement(branch.node)) {
               return
             }
 
             // check shortcircuit syntax like `x && x()` and `y || x()``
-            var prevSegments = segment.prevSegments
-            for (var ii = prevSegments.length - 1; ii >= 0; --ii) {
-              var prevSegment = prevSegments[ii]
+            const prevSegments = segment.prevSegments
+            for (let ii = prevSegments.length - 1; ii >= 0; --ii) {
+              const prevSegment = prevSegments[ii]
               if (funcInfo.branchInfoMap[prevSegment.id].good) return
             }
 

--- a/rules/catch-or-return.js
+++ b/rules/catch-or-return.js
@@ -6,7 +6,7 @@
 
 'use strict'
 
-var isPromise = require('./lib/is-promise')
+const isPromise = require('./lib/is-promise')
 
 module.exports = {
   meta: {
@@ -15,9 +15,9 @@ module.exports = {
     }
   },
   create: function(context) {
-    var options = context.options[0] || {}
-    var allowThen = options.allowThen
-    var terminationMethod = options.terminationMethod || 'catch'
+    const options = context.options[0] || {}
+    const allowThen = options.allowThen
+    let terminationMethod = options.terminationMethod || 'catch'
 
     if (typeof terminationMethod === 'string') {
       terminationMethod = [terminationMethod]

--- a/rules/lib/has-promise-callback.js
+++ b/rules/lib/has-promise-callback.js
@@ -9,7 +9,7 @@
 function hasPromiseCallback(node) {
   if (node.type !== 'CallExpression') return
   if (node.callee.type !== 'MemberExpression') return
-  var propertyName = node.callee.property.name
+  const propertyName = node.callee.property.name
   return propertyName === 'then' || propertyName === 'catch'
 }
 

--- a/rules/lib/is-callback.js
+++ b/rules/lib/is-callback.js
@@ -1,12 +1,12 @@
 'use strict'
 
-var isNamedCallback = require('./is-named-callback')
+const isNamedCallback = require('./is-named-callback')
 
 function isCallingBack(node, exceptions) {
-  var isCallExpression = node.type === 'CallExpression'
-  var callee = node.callee || {}
-  var nameIsCallback = isNamedCallback(callee.name, exceptions)
-  var isCB = isCallExpression && nameIsCallback
+  const isCallExpression = node.type === 'CallExpression'
+  const callee = node.callee || {}
+  const nameIsCallback = isNamedCallback(callee.name, exceptions)
+  const isCB = isCallExpression && nameIsCallback
   return isCB
 }
 

--- a/rules/lib/is-inside-callback.js
+++ b/rules/lib/is-inside-callback.js
@@ -1,9 +1,9 @@
 'use strict'
 
-var isInsidePromise = require('./is-inside-promise')
+const isInsidePromise = require('./is-inside-promise')
 
 function isInsideCallback(node) {
-  var isCallExpression =
+  const isCallExpression =
     node.type === 'FunctionExpression' ||
     node.type === 'ArrowFunctionExpression' ||
     node.type === 'FunctionDeclaration' // this may be controversial
@@ -11,9 +11,9 @@ function isInsideCallback(node) {
   // it's totally fine to use promises inside promises
   if (isInsidePromise(node)) return
 
-  var name = node.params && node.params[0] && node.params[0].name
-  var firstArgIsError = name === 'err' || name === 'error'
-  var isInACallback = isCallExpression && firstArgIsError
+  const name = node.params && node.params[0] && node.params[0].name
+  const firstArgIsError = name === 'err' || name === 'error'
+  const isInACallback = isCallExpression && firstArgIsError
   return isInACallback
 }
 

--- a/rules/lib/is-inside-promise.js
+++ b/rules/lib/is-inside-promise.js
@@ -1,14 +1,14 @@
 'use strict'
 
 function isInsidePromise(node) {
-  var isFunctionExpression =
+  const isFunctionExpression =
     node.type === 'FunctionExpression' ||
     node.type === 'ArrowFunctionExpression'
-  var parent = node.parent || {}
-  var callee = parent.callee || {}
-  var name = (callee.property && callee.property.name) || ''
-  var parentIsPromise = name === 'then' || name === 'catch'
-  var isInCB = isFunctionExpression && parentIsPromise
+  const parent = node.parent || {}
+  const callee = parent.callee || {}
+  const name = (callee.property && callee.property.name) || ''
+  const parentIsPromise = name === 'then' || name === 'catch'
+  const isInCB = isFunctionExpression && parentIsPromise
   return isInCB
 }
 

--- a/rules/lib/is-named-callback.js
+++ b/rules/lib/is-named-callback.js
@@ -1,9 +1,9 @@
 'use strict'
 
-var callbacks = ['done', 'cb', 'callback', 'next']
+let callbacks = ['done', 'cb', 'callback', 'next']
 
 module.exports = function isNamedCallback(potentialCallbackName, exceptions) {
-  for (var i = 0; i < exceptions.length; i++) {
+  for (let i = 0; i < exceptions.length; i++) {
     callbacks = callbacks.filter(function(item) {
       return item !== exceptions[i]
     })

--- a/rules/lib/is-promise.js
+++ b/rules/lib/is-promise.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-var STATIC_METHODS = ['all', 'race', 'reject', 'resolve']
+const STATIC_METHODS = ['all', 'race', 'reject', 'resolve']
 
 function isPromise(expression) {
   return (

--- a/rules/no-callback-in-promise.js
+++ b/rules/no-callback-in-promise.js
@@ -5,9 +5,9 @@
 
 'use strict'
 
-var hasPromiseCallback = require('./lib/has-promise-callback')
-var isInsidePromise = require('./lib/is-inside-promise')
-var isCallback = require('./lib/is-callback')
+const hasPromiseCallback = require('./lib/has-promise-callback')
+const isInsidePromise = require('./lib/is-inside-promise')
+const isCallback = require('./lib/is-callback')
 
 module.exports = {
   meta: {
@@ -19,13 +19,13 @@ module.exports = {
   create: function(context) {
     return {
       CallExpression: function(node) {
-        var options = context.options[0] || {}
-        var exceptions = options.exceptions || []
+        const options = context.options[0] || {}
+        const exceptions = options.exceptions || []
         if (!isCallback(node, exceptions)) {
           // in general we send you packing if you're not a callback
           // but we also need to watch out for whatever.then(cb)
           if (hasPromiseCallback(node)) {
-            var name =
+            const name =
               node.arguments && node.arguments[0] && node.arguments[0].name
             if (
               name === 'callback' ||

--- a/rules/no-native.js
+++ b/rules/no-native.js
@@ -24,7 +24,7 @@ module.exports = {
     }
   },
   create: function(context) {
-    var MESSAGE = '"{{name}}" is not defined.'
+    const MESSAGE = '"{{name}}" is not defined.'
 
     /**
      * Checks for and reports reassigned constants
@@ -35,7 +35,7 @@ module.exports = {
      */
     return {
       'Program:exit': function() {
-        var scope = context.getScope()
+        const scope = context.getScope()
 
         scope.implicit.left.forEach(function(ref) {
           if (ref.identifier.name !== 'Promise') {

--- a/rules/no-nesting.js
+++ b/rules/no-nesting.js
@@ -5,8 +5,8 @@
 
 'use strict'
 
-var hasPromiseCallback = require('./lib/has-promise-callback')
-var isInsidePromise = require('./lib/is-inside-promise')
+const hasPromiseCallback = require('./lib/has-promise-callback')
+const isInsidePromise = require('./lib/is-inside-promise')
 
 module.exports = {
   meta: {

--- a/rules/no-promise-in-callback.js
+++ b/rules/no-promise-in-callback.js
@@ -5,8 +5,8 @@
 
 'use strict'
 
-var isPromise = require('./lib/is-promise')
-var isInsideCallback = require('./lib/is-inside-callback')
+const isPromise = require('./lib/is-promise')
+const isInsideCallback = require('./lib/is-inside-callback')
 
 module.exports = {
   meta: {

--- a/rules/no-return-in-finally.js
+++ b/rules/no-return-in-finally.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var isPromise = require('./lib/is-promise')
+const isPromise = require('./lib/is-promise')
 
 module.exports = {
   meta: {

--- a/rules/no-return-wrap.js
+++ b/rules/no-return-wrap.js
@@ -6,12 +6,12 @@
 
 'use strict'
 
-var isPromise = require('./lib/is-promise')
-var rejectMessage = 'Expected throw instead of Promise.reject'
-var resolveMessage = 'Avoid wrapping return values in Promise.resolve'
+const isPromise = require('./lib/is-promise')
+const rejectMessage = 'Expected throw instead of Promise.reject'
+const resolveMessage = 'Avoid wrapping return values in Promise.resolve'
 
 function isInPromise(context) {
-  var expression = context.getAncestors().filter(function(node) {
+  const expression = context.getAncestors().filter(function(node) {
     return node.type === 'ExpressionStatement'
   })[0]
   return expression && expression.expression && isPromise(expression.expression)
@@ -24,8 +24,8 @@ module.exports = {
     }
   },
   create: function(context) {
-    var options = context.options[0] || {}
-    var allowReject = options.allowReject
+    const options = context.options[0] || {}
+    const allowReject = options.allowReject
 
     return {
       ReturnStatement: function(node) {

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -10,7 +10,7 @@ module.exports = {
     return {
       NewExpression: function(node) {
         if (node.callee.name === 'Promise' && node.arguments.length === 1) {
-          var params = node.arguments[0].params
+          const params = node.arguments[0].params
 
           if (!params || !params.length) {
             return

--- a/rules/prefer-await-to-callbacks.js
+++ b/rules/prefer-await-to-callbacks.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-var errorMessage = 'Avoid callbacks. Prefer Async/Await.'
+const errorMessage = 'Avoid callbacks. Prefer Async/Await.'
 
 module.exports = {
   meta: {
@@ -16,8 +16,8 @@ module.exports = {
   },
   create: function(context) {
     function checkLastParamsForCallback(node) {
-      var len = node.params.length - 1
-      var lastParam = node.params[len]
+      const len = node.params.length - 1
+      const lastParam = node.params[len]
       if (
         lastParam &&
         (lastParam.name === 'callback' || lastParam.name === 'cb')
@@ -41,9 +41,9 @@ module.exports = {
         }
 
         // thennables aren't allowed either
-        var args = node.arguments
-        var num = args.length - 1
-        var arg = num > -1 && node.arguments && node.arguments[num]
+        const args = node.arguments
+        const num = args.length - 1
+        const arg = num > -1 && node.arguments && node.arguments[num]
         if (
           (arg && arg.type === 'FunctionExpression') ||
           arg.type === 'ArrowFunctionExpression'


### PR DESCRIPTION
https://eslint.org/docs/rules/prefer-const

let and const better communicate if a variable is reassigned, and it is
possible to use them in all files since 'use strict' is enabled (#100).