### PR TITLE
docs: Use link to tagged version for rule docs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,12 +18,6 @@
     "prefer-const": "error",
     "strict": ["error", "global"],
     "eslint-plugin/prefer-placeholders": "error",
-    "eslint-plugin/require-meta-docs-url": [
-      "error",
-      {
-        "pattern": "https://github.com/xjamundx/eslint-plugin-promise#{{name}}"
-      }
-    ],
     "eslint-plugin/test-case-shorthand-strings": "error",
     "node/no-unsupported-features": ["error", { "version": 4 }],
     "prettier/prettier": "error"

--- a/rules/always-return.js
+++ b/rules/always-return.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
+
 function isFunctionWithBlockStatement(node) {
   if (node.type === 'FunctionExpression') {
     return true
@@ -55,7 +57,7 @@ function peek(arr) {
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#always-return'
+      url: getDocsUrl('always-return')
     }
   },
   create: function(context) {

--- a/rules/avoid-new.js
+++ b/rules/avoid-new.js
@@ -5,10 +5,12 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
+
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#avoid-new'
+      url: getDocsUrl('avoid-new')
     }
   },
   create: function(context) {

--- a/rules/catch-or-return.js
+++ b/rules/catch-or-return.js
@@ -6,12 +6,13 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
 const isPromise = require('./lib/is-promise')
 
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#catch-or-return'
+      url: getDocsUrl('catch-or-return')
     }
   },
   create: function(context) {

--- a/rules/lib/get-docs-url.js
+++ b/rules/lib/get-docs-url.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const pkg = require('../../package')
+
+const REPO_URL = 'https://github.com/xjamundx/eslint-plugin-promise'
+
+/**
+ * Generates the URL to documentation for the given rule name. It uses the
+ * package version to build the link to a tagged version of the
+ * documentation file.
+ *
+ * @param {string} ruleName - Name of the eslint rule
+ * @returns {string} URL to the documentation for the given rule
+ */
+function getDocsUrl(ruleName) {
+  return `${REPO_URL}/tree/v${pkg.version}#${ruleName}`
+}
+
+module.exports = getDocsUrl

--- a/rules/no-callback-in-promise.js
+++ b/rules/no-callback-in-promise.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
 const hasPromiseCallback = require('./lib/has-promise-callback')
 const isInsidePromise = require('./lib/is-inside-promise')
 const isCallback = require('./lib/is-callback')
@@ -12,8 +13,7 @@ const isCallback = require('./lib/is-callback')
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/xjamundx/eslint-plugin-promise#no-callback-in-promise'
+      url: getDocsUrl('no-callback-in-promise')
     }
   },
   create: function(context) {

--- a/rules/no-native.js
+++ b/rules/no-native.js
@@ -3,6 +3,8 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
+
 function isDeclared(scope, ref) {
   return scope.variables.some(function(variable) {
     if (variable.name !== ref.identifier.name) {
@@ -20,7 +22,7 @@ function isDeclared(scope, ref) {
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-native'
+      url: getDocsUrl('no-native')
     }
   },
   create: function(context) {

--- a/rules/no-nesting.js
+++ b/rules/no-nesting.js
@@ -5,13 +5,14 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
 const hasPromiseCallback = require('./lib/has-promise-callback')
 const isInsidePromise = require('./lib/is-inside-promise')
 
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-nesting'
+      url: getDocsUrl('no-nesting')
     }
   },
   create: function(context) {

--- a/rules/no-promise-in-callback.js
+++ b/rules/no-promise-in-callback.js
@@ -5,14 +5,14 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
 const isPromise = require('./lib/is-promise')
 const isInsideCallback = require('./lib/is-inside-callback')
 
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/xjamundx/eslint-plugin-promise#no-promise-in-callback'
+      url: getDocsUrl('no-promise-in-callback')
     }
   },
   create: function(context) {

--- a/rules/no-return-in-finally.js
+++ b/rules/no-return-in-finally.js
@@ -1,12 +1,12 @@
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
 const isPromise = require('./lib/is-promise')
 
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/xjamundx/eslint-plugin-promise#no-return-in-finally'
+      url: getDocsUrl('no-return-in-finally')
     }
   },
   create: function(context) {

--- a/rules/no-return-wrap.js
+++ b/rules/no-return-wrap.js
@@ -6,6 +6,7 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
 const isPromise = require('./lib/is-promise')
 const rejectMessage = 'Expected throw instead of Promise.reject'
 const resolveMessage = 'Avoid wrapping return values in Promise.resolve'
@@ -20,7 +21,7 @@ function isInPromise(context) {
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-return-wrap'
+      url: getDocsUrl('no-return-wrap')
     }
   },
   create: function(context) {

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -1,9 +1,11 @@
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
+
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#param-names'
+      url: getDocsUrl('param-names')
     },
     fixable: 'code'
   },

--- a/rules/prefer-await-to-callbacks.js
+++ b/rules/prefer-await-to-callbacks.js
@@ -5,13 +5,14 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
+
 const errorMessage = 'Avoid callbacks. Prefer Async/Await.'
 
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/xjamundx/eslint-plugin-promise#prefer-await-to-callbacks'
+      url: getDocsUrl('prefer-await-to-callbacks')
     }
   },
   create: function(context) {

--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -5,11 +5,12 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
+
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/xjamundx/eslint-plugin-promise#prefer-await-to-then'
+      url: getDocsUrl('prefer-await-to-then')
     }
   },
   create: function(context) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

Documentation update

**What changes did you make? (Give an overview)**

This adds a helper to lib and uses the version present in package.json for generating the URL to tagged version of the rule documentation. I think this is good because the documentation will match the version the user has installed. This way, even if a rule is changed or removed in the future, the user can find the documentation with ease.

Note: The rule `eslint-plugin/require-meta-docs-url` cannot be used with a function which would return the URL(see [not-an-aardvark/eslint-plugin-eslint-plugin#58](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/58)) so I have disabled it.