### PR TITLE
docs: add examples to `prefer-await-to-then`

### DIFF
--- a/docs/rules/prefer-await-to-then.md
+++ b/docs/rules/prefer-await-to-then.md
@@ -1,1 +1,36 @@
 # Prefer `await` to `then()` for reading Promise values (prefer-await-to-then)
+
+#### Valid
+
+```js
+async function example() {
+  let val = await myPromise()
+  val = doSomethingSync(val)
+  return doSomethingElseAsync(val)
+}
+
+async function exampleTwo() {
+  try {
+    let val = await myPromise()
+    val = doSomethingSync(val)
+    return await doSomethingElseAsync(val)
+  } catch (err) {
+    errors(err)
+  }
+}
+```
+
+#### Invalid
+
+```js
+function example() {
+  return myPromise.then(doSomethingSync).then(doSomethingElseAsync)
+}
+
+function exampleTwo() {
+  return myPromise
+    .then(doSomethingSync)
+    .then(doSomethingElseAsync)
+    .catch(errors)
+}
+```


### PR DESCRIPTION
**What is the purpose of this pull request?**

* [x] Documentation update

**What changes did you make? (Give an overview)**

Adds valid and invalid examples to `prefer-await-to-then` rule documentation.