### PR TITLE
refactor: lookup promise statics from object instead of array

### DIFF
--- a/rules/lib/is-promise.js
+++ b/rules/lib/is-promise.js
@@ -29,7 +29,7 @@ function isPromise(expression) {
       expression.callee.type === 'MemberExpression' &&
       expression.callee.object.type === 'Identifier' &&
       expression.callee.object.name === 'Promise' &&
-      PROMISE_STATICS.indexOf(expression.callee.property.name) !== -1)
+      PROMISE_STATICS[expression.callee.property.name])
   )
 }
 

--- a/rules/lib/promise-statics.js
+++ b/rules/lib/promise-statics.js
@@ -1,3 +1,8 @@
 'use strict'
 
-module.exports = ['all', 'race', 'reject', 'resolve']
+module.exports = {
+  all: true,
+  race: true,
+  reject: true,
+  resolve: true
+}

--- a/rules/no-new-statics.js
+++ b/rules/no-new-statics.js
@@ -15,7 +15,7 @@ module.exports = {
         if (
           node.callee.type === 'MemberExpression' &&
           node.callee.object.name === 'Promise' &&
-          PROMISE_STATICS.indexOf(node.callee.property.name) > -1
+          PROMISE_STATICS[node.callee.property.name]
         ) {
           context.report({
             node,


### PR DESCRIPTION
**What is the purpose of this pull request?**

* [ ] Documentation update
* [ ] Bug fix
* [ ] New rule
* [ ] Changes an existing rule
* [ ] Add autofixing to a rule
* [x] Other, please explain: minor optimization

**What changes did you make? (Give an overview)**

This is a small optimization to lookup Promise static method names from an object (O(1)) instead of an array (O(n)).