### PR TITLE
Fixed that `no-return-wrap` does not work if type is not "ExpressionStatement".

### DIFF
--- a/__tests__/no-return-wrap.js
+++ b/__tests__/no-return-wrap.js
@@ -202,6 +202,18 @@ ruleTester.run('no-return-wrap', rule, {
     {
       code: 'doThing().then(() => { return Promise.resolve(4) })',
       errors: [{ message: resolveMessage }]
+    },
+
+    // issue #150
+    {
+      code: `
+      function a () {
+        return p.then(function(val) {
+          return Promise.resolve(val * 4)
+        })
+      }
+      `,
+      errors: [{ message: resolveMessage }]
     }
   ]
 })

--- a/rules/no-return-wrap.js
+++ b/rules/no-return-wrap.js
@@ -10,10 +10,29 @@ const getDocsUrl = require('./lib/get-docs-url')
 const isPromise = require('./lib/is-promise')
 
 function isInPromise(context) {
-  const expression = context
+  let functionNode = context
     .getAncestors()
-    .filter(node => node.type === 'ExpressionStatement')[0]
-  return expression && expression.expression && isPromise(expression.expression)
+    .filter(node => {
+      return (
+        node.type === 'ArrowFunctionExpression' ||
+        node.type === 'FunctionExpression'
+      )
+    })
+    .reverse()[0]
+  while (
+    functionNode &&
+    functionNode.parent &&
+    functionNode.parent.type === 'MemberExpression' &&
+    functionNode.parent.object === functionNode &&
+    functionNode.parent.property.type === 'Identifier' &&
+    functionNode.parent.property.name === 'bind' &&
+    functionNode.parent.parent &&
+    functionNode.parent.parent.type === 'CallExpression' &&
+    functionNode.parent.parent.callee === functionNode.parent
+  ) {
+    functionNode = functionNode.parent.parent
+  }
+  return functionNode && functionNode.parent && isPromise(functionNode.parent)
 }
 
 module.exports = {


### PR DESCRIPTION
**What is the purpose of this pull request?**

* Fixed that `no-return-wrap` does not work if type is not "ExpressionStatement".
    (ex. "ReturnStatement" argument,"CallExpression" argument)
* Fixed that `no-return-wrap` does not work if multiple "ExpressionStatement" exists in the ancestor of "ReturnStatement".

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

I changed to search for the ancestor of "FunctionExpression" closest to "ReturnStatement" and to check if the parent node of that "FunctionExpression" is `Promise`.


Close #150 