### PR TITLE
Fixed incorrect description of document.

### DIFF
--- a/docs/rules/no-return-wrap.md
+++ b/docs/rules/no-return-wrap.md
@@ -32,31 +32,3 @@ myPromise.then(function(val) {
 Pass `{ allowReject: true }` as an option to this rule to permit wrapping
 returned values with `Promise.reject`, such as when you would use it as another
 way to reject the promise.
-
-### `param-names`
-
-Enforce standard parameter names for Promise constructors
-
-:wrench: The `--fix` option on the command line can automatically fix some of
-the problems reported by this rule.
-
-#### Valid
-
-```js
-new Promise(function (resolve) { ... })
-new Promise(function (resolve, reject) { ... })
-```
-
-#### Invalid
-
-```js
-new Promise(function (reject, resolve) { ... }) // incorrect order
-new Promise(function (ok, fail) { ... }) // non-standard parameter names
-```
-
-Ensures that `new Promise()` is instantiated with the parameter names
-`resolve, reject` to avoid confusion with order such as `reject, resolve`. The
-Promise constructor uses the
-[RevealingConstructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/).
-Using the same parameter names as the language specification makes code more
-uniform and easier to understand.

--- a/docs/rules/param-names.md
+++ b/docs/rules/param-names.md
@@ -1,1 +1,27 @@
 # Enforce consistent param names when creating new promises (param-names)
+
+Enforce standard parameter names for Promise constructors
+
+:wrench: The `--fix` option on the command line can automatically fix some of
+the problems reported by this rule.
+
+#### Valid
+
+```js
+new Promise(function (resolve) { ... })
+new Promise(function (resolve, reject) { ... })
+```
+
+#### Invalid
+
+```js
+new Promise(function (reject, resolve) { ... }) // incorrect order
+new Promise(function (ok, fail) { ... }) // non-standard parameter names
+```
+
+Ensures that `new Promise()` is instantiated with the parameter names
+`resolve, reject` to avoid confusion with order such as `reject, resolve`. The
+Promise constructor uses the
+[RevealingConstructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/).
+Using the same parameter names as the language specification makes code more
+uniform and easier to understand.


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [X] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fixed incorrect description of document.
The description of `param-names` was listed in` no-return-wrap`.
