### PR TITLE
Fix #139: make it more clear that param-names includes ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ or start with the recommended rule set
 | -------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------- | -------- |
 | [`catch-or-return`][catch-or-return]                     | Enforces the use of `catch()` on un-returned promises.                           | :bangbang:  |          |
 | [`no-return-wrap`][no-return-wrap]                       | Avoid wrapping values in `Promise.resolve` or `Promise.reject` when not needed.  | :bangbang:  |          |
-| [`param-names`][param-names]                             | Enforce consistent param names when creating new promises.                       | :bangbang:  | :wrench: |
+| [`param-names`][param-names]                             | Enforce consistent param names and ordering when creating new promises.          | :bangbang:  | :wrench: |
 | [`always-return`][always-return]                         | Return inside each `then()` to create readable and reusable Promise chains.      | :bangbang:  |          |
 | [`no-native`][no-native]                                 | In an ES5 environment, make sure to create a `Promise` constructor before using. |             |          |
 | [`no-nesting`][no-nesting]                               | Avoid nested `then()` or `catch()` statements                                    | :warning:   |          |


### PR DESCRIPTION
Following up on discussion in #139, I think it might be good to explicitly call out the ordering aspect of `param-names` in your `README` table.  It's clear when you read https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/param-names.md, but I know *I* missed that when I only looked at the `README` summary.