### PR TITLE
Add allowFinally option to catch-or-return rule

### DIFF
--- a/__tests__/catch-or-return.js
+++ b/__tests__/catch-or-return.js
@@ -89,6 +89,21 @@ ruleTester.run('catch-or-return', rule, {
       options: [{ allowThen: true }]
     },
 
+    // allowFinally - .finally(fn)
+    {
+      code: 'frank().then(go).catch(doIt).finally(fn)',
+      options: [{ allowFinally: true }]
+    },
+    {
+      code: 'frank().then(go).then().then().then().catch(doIt).finally(fn)',
+      options: [{ allowFinally: true }]
+    },
+    {
+      code:
+        'frank().then(go).then().catch(function() { /* why bother */ }).finally(fn)',
+      options: [{ allowFinally: true }]
+    },
+
     // terminationMethod=done - .done(null, fn)
     {
       code: 'frank().then(go).done()',
@@ -129,7 +144,28 @@ ruleTester.run('catch-or-return', rule, {
       errors: [{ message: catchMessage }]
     },
     {
-      code: 'frank.then(to).finally(fn)',
+      code: 'frank().then(to).catch(fn).then(foo)',
+      errors: [{ message: catchMessage }]
+    },
+    {
+      code: 'frank().finally(fn)',
+      errors: [{ message: catchMessage }]
+    },
+    {
+      code: 'frank().then(to).finally(fn)',
+      errors: [{ message: catchMessage }]
+    },
+    {
+      code: 'frank().then(go).catch(doIt).finally(fn)',
+      errors: [{ message: catchMessage }]
+    },
+    {
+      code: 'frank().then(go).then().then().then().catch(doIt).finally(fn)',
+      errors: [{ message: catchMessage }]
+    },
+    {
+      code:
+        'frank().then(go).then().catch(function() { /* why bother */ }).finally(fn)',
       errors: [{ message: catchMessage }]
     },
 
@@ -148,6 +184,13 @@ ruleTester.run('catch-or-return', rule, {
     },
     {
       code: 'function a() { frank.then(go).then(to) }',
+      errors: [{ message: catchMessage }]
+    },
+
+    // allowFinally=true failures
+    {
+      code: 'frank().then(go).catch(doIt).finally(fn).then(foo)',
+      options: [{ allowFinally: true }],
       errors: [{ message: catchMessage }]
     },
 

--- a/__tests__/catch-or-return.js
+++ b/__tests__/catch-or-return.js
@@ -193,6 +193,11 @@ ruleTester.run('catch-or-return', rule, {
       options: [{ allowFinally: true }],
       errors: [{ message: catchMessage }]
     },
+    {
+      code: 'frank().then(go).catch(doIt).finally(fn).foobar(foo)',
+      options: [{ allowFinally: true }],
+      errors: [{ message: catchMessage }]
+    },
 
     // terminationMethod=done - .done(null, fn)
     {
@@ -204,6 +209,12 @@ ruleTester.run('catch-or-return', rule, {
       code: 'frank().catch(go)',
       options: [{ terminationMethod: 'done' }],
       errors: [{ message: doneMessage }]
+    },
+
+    // assume somePromise.ANYTHING() is a new promise
+    {
+      code: 'frank().catch(go).someOtherMethod()',
+      errors: [{ message: catchMessage }]
     }
   ]
 })

--- a/docs/rules/catch-or-return.md
+++ b/docs/rules/catch-or-return.md
@@ -34,6 +34,13 @@ You can pass an `{ allowThen: true }` as an option to this rule to allow for
 `.then(null, fn)` to be used instead of `catch()` at the end of the promise
 chain.
 
+##### `allowFinally`
+
+You can pass an `{ allowFinally: true }` as an option to this rule to allow for
+`.finally(fn)` to be used after `catch()` at the end of the promise chain. This
+is different from adding `'finally'` as a `terminationMethod` because it will
+still require the Promise chain to be "caught" beforehand.
+
 ##### `terminationMethod`
 
 You can pass a `{ terminationMethod: 'done' }` as an option to this rule to

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2163,7 +2164,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2184,12 +2186,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2204,17 +2208,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2331,7 +2338,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2343,6 +2351,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2357,6 +2366,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2364,12 +2374,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2388,6 +2400,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2468,7 +2481,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2480,6 +2494,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2565,7 +2580,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2601,6 +2617,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2620,6 +2637,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2663,12 +2681,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5135,7 +5155,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "longest-streak": {
       "version": "1.0.0",


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This adds the `allowFinally` option to `catch-or-return` as described in #158.  This allows the use of `.finally()` _after_ a Promise chain has been "caught".

Closes #158 