### PR TITLE
fix(rulesMeta): update invalid rule docs url in rule's metadata

### DIFF
--- a/rules/lib/get-docs-url.js
+++ b/rules/lib/get-docs-url.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const pkg = require('../../package')
-
 const REPO_URL = 'https://github.com/xjamundx/eslint-plugin-promise'
 
 /**
@@ -13,7 +11,7 @@ const REPO_URL = 'https://github.com/xjamundx/eslint-plugin-promise'
  * @returns {string} URL to the documentation for the given rule
  */
 function getDocsUrl(ruleName) {
-  return `${REPO_URL}/tree/v${pkg.version}/docs/rules/${ruleName}.md`
+  return `${REPO_URL}/blob/master/docs/rules/${ruleName}.md`
 }
 
 module.exports = getDocsUrl


### PR DESCRIPTION
 **What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
When use eslint's node.js api to get rule's metadata(CLIEngine.getRules()), unfortunately, this plugin's rule's doc url is invalid(404). for example:

[https://github.com/xjamundx/eslint-plugin-promise/tree/v4.1.1/docs/rules/prefer-await-to-then.md](https://github.com/xjamundx/eslint-plugin-promise/tree/v4.1.1/docs/rules/prefer-await-to-then.md)

which should be modified as 

[https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-then.md](https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-then.md)


@xjamundx @macklinu   please take a look at this:)

