### PR TITLE
Simplify Invalid examples for the no-nesting rule

### DIFF
--- a/docs/rules/no-nesting.md
+++ b/docs/rules/no-nesting.md
@@ -12,19 +12,19 @@ myPromise
 #### Invalid
 
 ```js
-myPromise.then(val => {
+myPromise.then(val =>
   doSomething(val).then(doSomethingElse)
-})
+)
 
-myPromise.then(val => {
+myPromise.then(val =>
   doSomething(val).catch(errors)
-})
+)
 
-myPromise.catch(err => {
+myPromise.catch(err =>
   doSomething(err).then(doSomethingElse)
-})
+)
 
-myPromise.catch(err => {
+myPromise.catch(err =>
   doSomething(err).catch(errors)
-})
+)
 ```


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
The Invalid examples were also violating the rule `always-return`, but now they don't.
