### PR TITLE
prefer-await-to-then should flag promise.catch/finally as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ or start with the recommended rule set:
 | [`no-new-statics`][no-new-statics]                       | Avoid calling `new` on a Promise static method                                   | :bangbang:  | :wrench: |
 | [`no-return-in-finally`][no-return-in-finally]           | Disallow return statements in `finally()`                                        | :warning:   |          |
 | [`valid-params`][valid-params]                           | Ensures the proper number of arguments are passed to Promise functions           | :warning:   |          |
-| [`prefer-await-to-then`][prefer-await-to-then]           | Prefer `await` to `then()` for reading Promise values                            | :seven:     |          |
+| [`prefer-await-to-then`][prefer-await-to-then]           | Prefer `await` to `then()`/`catch()`/`finally()` for reading Promise values                            | :seven:     |          |
 | [`prefer-await-to-callbacks`][prefer-await-to-callbacks] | Prefer async/await to the callback pattern                                       | :seven:     |          |
 
 **Key**

--- a/__tests__/prefer-await-to-then.js
+++ b/__tests__/prefer-await-to-then.js
@@ -8,7 +8,7 @@ const ruleTester = new RuleTester({
   }
 })
 
-const message = 'Prefer await to then().'
+const message = 'Prefer await to then()/catch()/finally().'
 
 ruleTester.run('prefer-await-to-then', rule, {
   valid: [
@@ -16,6 +16,7 @@ ruleTester.run('prefer-await-to-then', rule, {
     'async function hi() { await thing().then() }',
     'async function hi() { await thing().catch() }',
     'a = async () => (await something())',
+    'a = async () => (try { await something() } catch { somethingElse() })',
     'something().then(async () => await somethingElse())'
   ],
 
@@ -36,6 +37,14 @@ ruleTester.run('prefer-await-to-then', rule, {
       code:
         'async function a() { hey.then(function() { }).then(function() { }) }',
       errors: [{ message }, { message }]
+    },
+    {
+      code: 'function foo() { hey.catch(x => {}) }',
+      errors: [{ message }]
+    },
+    {
+      code: 'function foo() { hey.finally(x => {}) }',
+      errors: [{ message }]
     }
   ]
 })

--- a/docs/rules/prefer-await-to-then.md
+++ b/docs/rules/prefer-await-to-then.md
@@ -1,4 +1,4 @@
-# Prefer `await` to `then()` for reading Promise values (prefer-await-to-then)
+# Prefer `await` to `then()`/`catch()`/`finally()` for reading Promise values (prefer-await-to-then)
 
 #### Valid
 
@@ -32,5 +32,15 @@ function exampleTwo() {
     .then(doSomethingSync)
     .then(doSomethingElseAsync)
     .catch(errors)
+}
+
+function exampleThree() {
+  return myPromise
+    .catch(errors)
+}
+
+function exampleFour() {
+  return myPromise
+    .finally(cleanup)
 }
 ```

--- a/rules/prefer-await-to-then.js
+++ b/rules/prefer-await-to-then.js
@@ -1,6 +1,6 @@
 /**
  * Rule: prefer-await-to-then
- * Discourage using then() and instead use async/await.
+ * Discourage using then()/catch()/finally() and instead use async/await.
  */
 
 'use strict'
@@ -38,11 +38,11 @@ module.exports = {
           return
         }
 
-        // if you're a then expression then you're probably a promise
-        if (node.property && node.property.name === 'then') {
+        // if you're a then/catch/finally expression then you're probably a promise
+        if (node.property && (node.property.name === 'then' || node.property.name === 'catch' || node.property.name === 'finally')) {
           context.report({
             node: node.property,
-            message: 'Prefer await to then().'
+            message: 'Prefer await to then()/catch()/finally().'
           })
         }
       }


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
Flag `catch()` and `finally()` usages in the `prefer-await-to-then` rule