### PR TITLE
fix(no-return-wrap): fix it not reporting for arrow functions without braces

### DIFF
--- a/__tests__/no-return-wrap.js
+++ b/__tests__/no-return-wrap.js
@@ -54,7 +54,20 @@ ruleTester.run('no-return-wrap', rule, {
     },
 
     // not function bind
-    'doThing().then((function() { return Promise.resolve(4) }).toString())'
+    'doThing().then((function() { return Promise.resolve(4) }).toString())',
+
+    {
+      code: 'doThing().then(() => Promise.reject(4))',
+      options: [{ allowReject: true }]
+    },
+
+    // Call expressions that aren't Promise.resolve/reject
+    'doThing().then(function() { return a() })',
+    'doThing().then(function() { return Promise.a() })',
+    'doThing().then(() => { return a() })',
+    'doThing().then(() => { return Promise.a() })',
+    'doThing().then(() => a())',
+    'doThing().then(() => Promise.a())'
   ],
 
   invalid: [
@@ -115,7 +128,7 @@ ruleTester.run('no-return-wrap', rule, {
     // {code: 'doThing().catch(function(x) { return true ? Promise.resolve(4) : Promise.reject(5) })', errors: [{message: rejectMessage }, {message: resolveMessage}]},
     // {code: 'doThing().catch(function(x) { return x && Promise.reject(4) })', errors: [{message: rejectMessage}]}
 
-    // mltiple "ExpressionStatement"
+    // multiple "ExpressionStatement"
     {
       code: `
       fn(function() {
@@ -214,6 +227,16 @@ ruleTester.run('no-return-wrap', rule, {
       }
       `,
       errors: [{ message: resolveMessage }]
+    },
+
+    // issue #193
+    {
+      code: 'doThing().then(() => Promise.resolve(4))',
+      errors: [{ message: resolveMessage }]
+    },
+    {
+      code: 'doThing().then(() => Promise.reject(4))',
+      errors: [{ message: rejectMessage }]
     }
   ]
 })

--- a/rules/always-return.js
+++ b/rules/always-return.js
@@ -68,7 +68,7 @@ module.exports = {
     // funcInfoStack[i].branchInfoMap is an object representing information
     //   about all branches within the given function
     // funcInfoStack[i].branchInfoMap[j].good is a boolean representing whether
-    //   the given branch explictly `return`s or `throw`s. It starts as `false`
+    //   the given branch explicitly `return`s or `throw`s. It starts as `false`
     //   for every branch and is updated to `true` if a `return` or `throw`
     //   statement is found
     // funcInfoStack[i].branchInfoMap[j].loc is a eslint SourceLocation object

--- a/rules/lib/has-promise-callback.js
+++ b/rules/lib/has-promise-callback.js
@@ -1,5 +1,5 @@
 /**
- * Library: Has Promis eCallback
+ * Library: Has Promise Callback
  * Makes sure that an Expression node is part of a promise
  * with callback functions (like then() or catch())
  */


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
Checks CallExpressions that are direct descendants of ArrowFunctionExpressions (meaning that the arrow function returns a CallExpression without braces) and reports if it is `Promise.resolve` or `Promise.reject`.

Fixes #193.
