### PR TITLE
Drop Node < 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "^2.2.1"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "license": "ISC",
   "lint-staged": {


### PR DESCRIPTION
chore: update `engines` to reflect (maintained) versions of Node being tested in Travis

BREAKING CHANGE:

Requires Node 10.

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [x] Other, please explain:

Update `engines` in `package.json`.

**What changes did you make? (Give an overview)**

Given the recent changes to test only the currently maintained versions of Node (10, 12, 14), I wanted to offer this PR if you wanted to enforce that requirement, given that we are not verifying whether changes now are breaking earlier Node versions.