### PR TITLE
feat(rule) Warn for awaits without a try/catch wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Then configure the rules you want to use under the rules section.
     "promise/avoid-new": "warn",
     "promise/no-new-statics": "error",
     "promise/no-return-in-finally": "warn",
-    "promise/valid-params": "warn"
+    "promise/valid-params": "warn",
+    "promise/wrap-await-with-try-catch": "warn"
   }
 }
 ```
@@ -92,6 +93,7 @@ or start with the recommended rule set:
 | [`valid-params`][valid-params]                           | Ensures the proper number of arguments are passed to Promise functions           | :warning:   |          |
 | [`prefer-await-to-then`][prefer-await-to-then]           | Prefer `await` to `then()` for reading Promise values                            | :seven:     |          |
 | [`prefer-await-to-callbacks`][prefer-await-to-callbacks] | Prefer async/await to the callback pattern                                       | :seven:     |          |
+| [`wrap-await-with-try-catch`][wrap-await-with-try-catch] | Ensures `await` expressions are wrapped with a try/catch                         | :warning:   |          |
 
 **Key**
 
@@ -126,6 +128,7 @@ or start with the recommended rule set:
 [valid-params]: docs/rules/valid-params.md
 [prefer-await-to-then]: docs/rules/prefer-await-to-then.md
 [prefer-await-to-callbacks]: docs/rules/prefer-await-to-callbacks.md
+[wrap-await-with-try-catch]: docs/rules/wrap-await-with-try-catch.md
 [nodeify]: https://www.npmjs.com/package/nodeify
 [pify]: https://www.npmjs.com/package/pify
 [@macklinu]: https://github.com/macklinu

--- a/__tests__/wrap-await-with-try-catch.js
+++ b/__tests__/wrap-await-with-try-catch.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../rules/wrap-await-with-try-catch')
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8
+  }
+})
+
+const message = '"await"s must be wrapped with a try/catch statement.'
+
+ruleTester.run('wrap-await-with-try-catch', rule, {
+  valid: [
+    `async function test() { 
+        try {  
+            await doSomething()
+        }
+        catch(ex){
+            console.log(ex)
+        }
+    }`,
+    `async function test() { 
+        try {  
+            throw Error
+        }
+        catch(ex0){
+            try {
+                await doSomething()
+            }
+            catch(ex1) {
+                console.log(ex1)
+            }
+        }
+    }`
+  ],
+  invalid: [
+    {
+      code: 'async function hi() { await doSomething() }',
+      errors: [{ message }]
+    },
+    {
+      code: `async function test() { 
+            try {  
+                await doSomething()
+            }
+            finally {
+                console.log("ok.")
+            }
+        }`,
+      errors: [{ message }]
+    },
+    {
+      code: `async function test() { 
+            try {  
+                throw Error
+            }
+            catch (ex) {
+                await doSomethingOther()
+            }
+        }`,
+      errors: [{ message }]
+    }
+  ]
+})

--- a/__tests__/wrap-await-with-try-catch.js
+++ b/__tests__/wrap-await-with-try-catch.js
@@ -17,7 +17,7 @@ ruleTester.run('wrap-await-with-try-catch', rule, {
             await doSomething()
         }
         catch(ex){
-            console.log(ex)
+            errorHandler(ex)
         }
     }`,
     `async function test() { 
@@ -29,7 +29,7 @@ ruleTester.run('wrap-await-with-try-catch', rule, {
                 await doSomething()
             }
             catch(ex1) {
-                console.log(ex1)
+                errorHandler(ex1)
             }
         }
     }`,
@@ -40,12 +40,19 @@ ruleTester.run('wrap-await-with-try-catch', rule, {
                     await doSomething()
                 }
                 catch (ex) {
-                    console.log(ex)
+                    errorHandler(ex)
                 }
             })()
         }
         catch (ex) {
-            console.log(ex)
+            errorHandler(ex)
+        }
+    }`,
+    `var foo = async () => {
+        try {
+             await fetch();
+        } catch (error) {
+             errorHandler(error);
         }
     }`
   ],
@@ -60,7 +67,7 @@ ruleTester.run('wrap-await-with-try-catch', rule, {
                 await doSomething()
             }
             finally {
-                console.log("ok.")
+                errorHandler("ok.")
             }
         }`,
       errors: [{ message }]
@@ -84,9 +91,15 @@ ruleTester.run('wrap-await-with-try-catch', rule, {
                 })()
             }
             catch (ex) {
-                console.log(ex)
+                errorHandler(ex)
             }
         }`,
+      errors: [{ message }]
+    },
+    {
+      code: `var foo = async () => {
+        await fetch();
+    }`,
       errors: [{ message }]
     }
   ]

--- a/__tests__/wrap-await-with-try-catch.js
+++ b/__tests__/wrap-await-with-try-catch.js
@@ -32,6 +32,21 @@ ruleTester.run('wrap-await-with-try-catch', rule, {
                 console.log(ex1)
             }
         }
+    }`,
+    `async function test() { 
+        try {
+            (async function innerFn() {
+                try {
+                    await doSomething()
+                }
+                catch (ex) {
+                    console.log(ex)
+                }
+            })()
+        }
+        catch (ex) {
+            console.log(ex)
+        }
     }`
   ],
   invalid: [
@@ -57,6 +72,19 @@ ruleTester.run('wrap-await-with-try-catch', rule, {
             }
             catch (ex) {
                 await doSomethingOther()
+            }
+        }`,
+      errors: [{ message }]
+    },
+    {
+      code: `async function test() { 
+            try {
+                (async function innerFn() {
+                    await doSomething()
+                })()
+            }
+            catch (ex) {
+                console.log(ex)
             }
         }`,
       errors: [{ message }]

--- a/docs/rules/wrap-await-with-try-catch.md
+++ b/docs/rules/wrap-await-with-try-catch.md
@@ -1,8 +1,5 @@
 # Wrap awaits with try/catch blocks (wrap-await-with-try-catch)
 
-Calling a Promise static method with `new` is invalid, resulting in a
-`TypeError` at runtime.
-
 ## Rule Details
 
 This rule is aimed at flagging awaits where they are not checked for possible rejections.

--- a/docs/rules/wrap-await-with-try-catch.md
+++ b/docs/rules/wrap-await-with-try-catch.md
@@ -1,0 +1,79 @@
+# Wrap awaits with try/catch blocks (wrap-await-with-try-catch)
+
+Calling a Promise static method with `new` is invalid, resulting in a
+`TypeError` at runtime.
+
+## Rule Details
+
+This rule is aimed at flagging awaits where they are not checked for possible rejections.
+
+Examples for **incorrect** code for this rule:
+
+```js
+await doSomething()
+```
+
+```js
+try {
+    ...
+}
+catch (ex) {
+    await doSomething();
+}
+```
+
+```js
+try {
+    (async function someFn(){
+        await doSomething();
+    })();
+}
+catch (ex) {
+    //...
+}
+```
+
+Examples for **correct** code for this rule:
+
+```js
+try {
+    await doSomething();
+}
+catch (ex) {
+    //...
+}
+```
+
+```js
+try {
+    //...
+}
+catch (ex0) {
+    try {
+        await doSomething();
+    }
+    catch (ex1) {
+        //...
+    }
+}
+```
+
+```js
+try {
+    (async function someFn(){
+        try {
+            await doSomething();
+        }
+        catch (exInner) {
+        //...
+        }
+    })();
+}
+catch (ex) {
+    //...
+}
+```
+
+## When Not To Use It
+
+If you handle awaits with a different error checking mechanism, you can disable this rule.

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ module.exports = {
     'avoid-new': require('./rules/avoid-new'),
     'no-new-statics': require('./rules/no-new-statics'),
     'no-return-in-finally': require('./rules/no-return-in-finally'),
-    'valid-params': require('./rules/valid-params')
+    'valid-params': require('./rules/valid-params'),
+    'wrap-await-with-try-catch': require('./rules/wrap-await-with-try-catch')
   },
   rulesConfig: {
     'param-names': 1,
@@ -39,7 +40,8 @@ module.exports = {
         'promise/avoid-new': 'off',
         'promise/no-new-statics': 'error',
         'promise/no-return-in-finally': 'warn',
-        'promise/valid-params': 'warn'
+        'promise/valid-params': 'warn',
+        'promise/wrap-await-with-try-catch': 'warn'
       }
     }
   }

--- a/rules/wrap-await-with-try-catch.js
+++ b/rules/wrap-await-with-try-catch.js
@@ -1,0 +1,64 @@
+/**
+ * Rule: wrap-await-with-try-catch
+ */
+
+'use strict'
+
+module.exports = {
+    rules: {
+        "wrap-await-with-try-catch": {
+            create: function(context) {
+                function isAwaitHandled() {
+                    var ancestors = context.getAncestors();
+                    var handledInOrder = [];
+
+                    ancestors.forEach((ancestor) => {
+                        if (ancestor.type === "TryStatement") {
+                            handledInOrder.push({name: "try", node: ancestor, relatedTry: ancestor});
+                        }
+                        else if (ancestor.type === "CatchClause") {
+                            handledInOrder.push({name: "catch", node: ancestor, relatedTry: ancestor.parent});
+                        }
+                        else if (ancestor.type === "BlockStatement" && ancestor.parent.finalizer === ancestor) {
+                            handledInOrder.push({name: "finally", node: ancestor, relatedTry: ancestor.parent});
+                        }
+                        else if (ancestor.type === "FunctionExpression" || ancestor.type === "FunctionDeclaration") {
+                            // clear the current parents, we are in a new function
+                            handledInOrder = [];
+                        }
+                    });
+
+                    if (handledInOrder.length === 0) {
+                        return false;
+                    }
+
+                    var lastItem = handledInOrder[handledInOrder.length - 1];
+
+                    while (handledInOrder.length > 0 && !(lastItem.name === "try" && lastItem.node.handler)) {
+                        var tryToBeDeleted = lastItem.relatedTry;
+
+                        while (handledInOrder.length > 0 && lastItem.relatedTry == tryToBeDeleted) {
+                            handledInOrder.pop();
+                            lastItem = handledInOrder[handledInOrder.length - 1];
+                        }
+                    }
+
+                    return handledInOrder.length > 0;
+                }
+
+                return {
+                    AwaitExpression(node) {
+                        if (isAwaitHandled()) {
+                            return;
+                        }
+
+                        context.report({
+                            node: node,
+                            message: '"await"s must be wrapped with a try/catch statement.'
+                        });
+                    }
+                };
+            }
+        }
+    }
+};

--- a/rules/wrap-await-with-try-catch.js
+++ b/rules/wrap-await-with-try-catch.js
@@ -4,61 +4,86 @@
 
 'use strict'
 
+const getDocsUrl = require('./lib/get-docs-url')
+
 module.exports = {
-    rules: {
-        "wrap-await-with-try-catch": {
-            create: function(context) {
-                function isAwaitHandled() {
-                    var ancestors = context.getAncestors();
-                    var handledInOrder = [];
-
-                    ancestors.forEach((ancestor) => {
-                        if (ancestor.type === "TryStatement") {
-                            handledInOrder.push({name: "try", node: ancestor, relatedTry: ancestor});
-                        }
-                        else if (ancestor.type === "CatchClause") {
-                            handledInOrder.push({name: "catch", node: ancestor, relatedTry: ancestor.parent});
-                        }
-                        else if (ancestor.type === "BlockStatement" && ancestor.parent.finalizer === ancestor) {
-                            handledInOrder.push({name: "finally", node: ancestor, relatedTry: ancestor.parent});
-                        }
-                        else if (ancestor.type === "FunctionExpression" || ancestor.type === "FunctionDeclaration") {
-                            // clear the current parents, we are in a new function
-                            handledInOrder = [];
-                        }
-                    });
-
-                    if (handledInOrder.length === 0) {
-                        return false;
-                    }
-
-                    var lastItem = handledInOrder[handledInOrder.length - 1];
-
-                    while (handledInOrder.length > 0 && !(lastItem.name === "try" && lastItem.node.handler)) {
-                        var tryToBeDeleted = lastItem.relatedTry;
-
-                        while (handledInOrder.length > 0 && lastItem.relatedTry == tryToBeDeleted) {
-                            handledInOrder.pop();
-                            lastItem = handledInOrder[handledInOrder.length - 1];
-                        }
-                    }
-
-                    return handledInOrder.length > 0;
-                }
-
-                return {
-                    AwaitExpression(node) {
-                        if (isAwaitHandled()) {
-                            return;
-                        }
-
-                        context.report({
-                            node: node,
-                            message: '"await"s must be wrapped with a try/catch statement.'
-                        });
-                    }
-                };
-            }
-        }
+  meta: {
+    type: 'suggestion',
+    docs: {
+      url: getDocsUrl('wrap-await-with-try-catch')
     }
-};
+  },
+  create(context) {
+    function isAwaitHandled() {
+      const ancestors = context.getAncestors()
+      let handledInOrder = []
+
+      ancestors.forEach(ancestor => {
+        if (ancestor.type === 'TryStatement') {
+          handledInOrder.push({
+            name: 'try',
+            node: ancestor,
+            relatedTry: ancestor
+          })
+        } else if (ancestor.type === 'CatchClause') {
+          handledInOrder.push({
+            name: 'catch',
+            node: ancestor,
+            relatedTry: ancestor.parent
+          })
+        } else if (
+          ancestor.type === 'BlockStatement' &&
+          ancestor.parent.finalizer === ancestor
+        ) {
+          handledInOrder.push({
+            name: 'finally',
+            node: ancestor,
+            relatedTry: ancestor.parent
+          })
+        } else if (
+          ancestor.type === 'FunctionExpression' ||
+          ancestor.type === 'FunctionDeclaration'
+        ) {
+          // clear the current parents, we are in a new function
+          handledInOrder = []
+        }
+      })
+
+      if (handledInOrder.length === 0) {
+        return false
+      }
+
+      let lastItem = handledInOrder[handledInOrder.length - 1]
+
+      while (
+        handledInOrder.length > 0 &&
+        !(lastItem.name === 'try' && lastItem.node.handler)
+      ) {
+        const tryToBeDeleted = lastItem.relatedTry
+
+        while (
+          handledInOrder.length > 0 &&
+          lastItem.relatedTry == tryToBeDeleted
+        ) {
+          handledInOrder.pop()
+          lastItem = handledInOrder[handledInOrder.length - 1]
+        }
+      }
+
+      return handledInOrder.length > 0
+    }
+
+    return {
+      AwaitExpression(node) {
+        if (isAwaitHandled()) {
+          return
+        }
+
+        context.report({
+          node,
+          message: '"await"s must be wrapped with a try/catch statement.'
+        })
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

I've created a new rule named wrap-await-with-try-catch, which warns you if you don’t have try/catch around your awaits. For instance,

This would cause a warning:
```js
await doSomething()
```

And this one is corrected:
```js
try {
    await doSomething();
}
catch (ex) {
    //...
}
```

The rule basically traverses ancestors of the await expression to find a try block that has a catch clause. It was slightly trickier to implement the idea, though. If we simply looked for a `TryStatement` parent, the await, which is wrapped by a catch or a finally block, could be recognized as valid since catch and finally are children of `try`. For instance,

In the following await still has a `TryStatement` as an ancestor, but it is invalid for our case:
```js
try {
    ...
}
catch (ex) {
    await doSomething();
}
```

And one of the possible fixes is below. The inner try/catch is ignored, we accept the outer one:
```js
try {
    try {
        ...
    }
    catch (ex) {
        await doSomething();
    }
}
catch (ex) {
}
```

That is, the await expression must be in a try block, no matter how much nested it is. I don't offer a fixer, since the possible scenarios can be too complex to fix automatically.