### PR TITLE
included check for string literal 'error'

### DIFF
--- a/__tests__/prefer-await-to-callbacks.js
+++ b/__tests__/prefer-await-to-callbacks.js
@@ -51,6 +51,14 @@ ruleTester.run('prefer-await-to-callbacks', rule, {
     {
       code: 'callback()',
       errors: [{ message }]
+    },
+    {
+      code: 'heart(error => {})',
+      errors: [{ message }]
+    },
+    {
+      code: 'heart(function(error) {})',
+      errors: [{ message }]
     }
   ]
 })

--- a/rules/prefer-await-to-callbacks.js
+++ b/rules/prefer-await-to-callbacks.js
@@ -50,7 +50,11 @@ module.exports = {
           ) {
             return
           }
-          if (arg.params && arg.params[0] && arg.params[0].name === 'err') {
+          if (
+            arg.params &&
+            arg.params[0] &&
+            (arg.params[0].name === 'err' || arg.params[0].name === 'error')
+          ) {
             if (!isInsideYieldOrAwait()) {
               context.report({ node: arg, messageId: 'error' })
             }


### PR DESCRIPTION
**What is the purpose of this pull request?**
Now shows an error if callback has "error" as the first param.

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
Original if statement only checked the first param name was "err". Now it also checks for "error"