### PR TITLE
param-names: Add support for unused `_` name

### DIFF
--- a/__tests__/param-names.js
+++ b/__tests__/param-names.js
@@ -13,7 +13,11 @@ const message = 'Promise constructor parameters must be named resolve, reject'
 ruleTester.run('param-names', rule, {
   valid: [
     'new Promise(function(resolve, reject) {})',
+    'new Promise(function(resolve, _reject) {})',
+    'new Promise(function(_resolve, reject) {})',
+    'new Promise(function(_resolve, _reject) {})',
     'new Promise(function(resolve) {})',
+    'new Promise(function(_resolve) {})',
     'new Promise(resolve => {})',
     'new Promise((resolve, reject) => {})',
     'new Promise(() => {})',

--- a/docs/rules/param-names.md
+++ b/docs/rules/param-names.md
@@ -7,6 +7,7 @@ Enforce standard parameter names for Promise constructors
 ```js
 new Promise(function (resolve) { ... })
 new Promise(function (resolve, reject) { ... })
+new Promise(function (_resolve, _reject) { ... }) // Unused marker for parameters are allowed
 ```
 
 #### Invalid

--- a/rules/param-names.js
+++ b/rules/param-names.js
@@ -20,8 +20,8 @@ module.exports = {
           }
 
           if (
-            params[0].name !== 'resolve' ||
-            (params[1] && params[1].name !== 'reject')
+            (params[0].name !== 'resolve' && params[0].name !== '_resolve') ||
+            (params[1] && params[1].name !== 'reject' && params[1].name !== '_reject')
           ) {
             context.report({
               node,


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [-] Documentation update
- [-] Bug fix
- [-] New rule
- [x] Changes an existing rule
- [-] Add autofixing to a rule
- [-] Other, please explain:

**What changes did you make? (Give an overview)**

I added the support for `_` prefixed names in promise param names. This is a convention for unused parameters.

Part of #206 