### PR TITLE
feat: add tests for @typescript-eslint/parser

### DIFF
--- a/__tests__/no-native.js
+++ b/__tests__/no-native.js
@@ -2,48 +2,57 @@
 
 const rule = require('../rules/no-native')
 const RuleTester = require('eslint').RuleTester
-const ruleTester = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: 'module',
-  },
-})
+const parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module',
+}
+const ruleTesters = [
+  new RuleTester({
+    parserOptions,
+  }),
+  new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions,
+  }),
+]
 
-ruleTester.run('no-native', rule, {
-  valid: [
-    'var Promise = null; function x() { return Promise.resolve("hi"); }',
-    'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();',
-    'import Promise from "bluebird"; var x = Promise.reject();',
-  ],
+for (const ruleTester of ruleTesters) {
+  ruleTester.run('no-native', rule, {
+    valid: [
+      'var Promise = null; function x() { return Promise.resolve("hi"); }',
+      'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();',
+      'import Promise from "bluebird"; var x = Promise.reject();',
+    ],
 
-  invalid: [
-    {
-      code: 'new Promise(function(reject, resolve) { })',
-      errors: [{ message: '"Promise" is not defined.' }],
-    },
-    {
-      code: 'Promise.resolve()',
-      errors: [{ message: '"Promise" is not defined.' }],
-    },
-    {
-      code: 'new Promise(function(reject, resolve) { })',
-      errors: [{ message: '"Promise" is not defined.' }],
-      env: { browser: true },
-    },
-    {
-      code: 'new Promise(function(reject, resolve) { })',
-      errors: [{ message: '"Promise" is not defined.' }],
-      env: { node: true },
-    },
-    {
-      code: 'Promise.resolve()',
-      errors: [{ message: '"Promise" is not defined.' }],
-      env: { es6: true },
-    },
-    {
-      code: 'Promise.resolve()',
-      errors: [{ message: '"Promise" is not defined.' }],
-      globals: { Promise: true },
-    },
-  ],
-})
+    invalid: [
+      {
+        code: 'new Promise(function(reject, resolve) { })',
+        errors: [{ message: '"Promise" is not defined.' }],
+      },
+      {
+        code: 'Promise.resolve()',
+        errors: [{ message: '"Promise" is not defined.' }],
+      },
+      {
+        code: 'new Promise(function(reject, resolve) { })',
+        errors: [{ message: '"Promise" is not defined.' }],
+        env: { browser: true },
+      },
+      {
+        code: 'new Promise(function(reject, resolve) { })',
+        errors: [{ message: '"Promise" is not defined.' }],
+        env: { node: true },
+      },
+      {
+        code: 'Promise.resolve()',
+        errors: [{ message: '"Promise" is not defined.' }],
+        env: { es6: true },
+      },
+      {
+        code: 'Promise.resolve()',
+        errors: [{ message: '"Promise" is not defined.' }],
+        globals: { Promise: true },
+      },
+    ],
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "eslint-plugin-promise",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-promise",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "ISC",
       "devDependencies": {
+        "@typescript-eslint/parser": "^5.35.1",
         "doctoc": "^2.1.0",
         "eslint": "^8.5.0",
         "eslint-config-prettier": "^8.3.0",
@@ -1230,6 +1231,116 @@
       },
       "peerDependencies": {
         "eslint": ">=5"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.35.1.tgz",
+      "integrity": "sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.35.1.tgz",
+      "integrity": "sha512-kCYRSAzIW9ByEIzmzGHE50NGAvAP3wFTaZevgWva7GpquDyFPFcmvVkFJGWJJktg/hLwmys/FZwqM9EKr2u24Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.35.1.tgz",
+      "integrity": "sha512-FDaujtsH07VHzG0gQ6NDkVVhi1+rhq0qEvzHdJAQjysN+LHDCKDKCBRlZFFE0ec0jKxiv0hN63SNfExy0KrbQQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.35.1.tgz",
+      "integrity": "sha512-JUqE1+VRTGyoXlDWWjm6MdfpBYVq+hixytrv1oyjYIBEOZhBCwtpp5ZSvBt4wIA1MKWlnaC2UXl2XmYGC3BoQA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.35.1.tgz",
+      "integrity": "sha512-cEB1DvBVo1bxbW/S5axbGPE6b7FIMAbo3w+AGq6zNDA7+NYJOIkKj/sInfTv4edxd4PxJSgdN4t6/pbvgA+n5g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.35.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -3042,9 +3153,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3054,7 +3165,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3298,16 +3409,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -3318,9 +3429,9 @@
       }
     },
     "node_modules/globby/node_modules/ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -5938,9 +6049,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -7725,6 +7836,67 @@
         }
       }
     },
+    "@typescript-eslint/parser": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.35.1.tgz",
+      "integrity": "sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.35.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.35.1.tgz",
+          "integrity": "sha512-kCYRSAzIW9ByEIzmzGHE50NGAvAP3wFTaZevgWva7GpquDyFPFcmvVkFJGWJJktg/hLwmys/FZwqM9EKr2u24Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.35.1",
+            "@typescript-eslint/visitor-keys": "5.35.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.35.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.35.1.tgz",
+          "integrity": "sha512-FDaujtsH07VHzG0gQ6NDkVVhi1+rhq0qEvzHdJAQjysN+LHDCKDKCBRlZFFE0ec0jKxiv0hN63SNfExy0KrbQQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.35.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.35.1.tgz",
+          "integrity": "sha512-JUqE1+VRTGyoXlDWWjm6MdfpBYVq+hixytrv1oyjYIBEOZhBCwtpp5ZSvBt4wIA1MKWlnaC2UXl2XmYGC3BoQA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.35.1",
+            "@typescript-eslint/visitor-keys": "5.35.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.35.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.35.1.tgz",
+          "integrity": "sha512-cEB1DvBVo1bxbW/S5axbGPE6b7FIMAbo3w+AGq6zNDA7+NYJOIkKj/sInfTv4edxd4PxJSgdN4t6/pbvgA+n5g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.35.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        }
+      }
+    },
     "@typescript-eslint/scope-manager": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz",
@@ -9038,9 +9210,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9232,23 +9404,23 @@
       }
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "ignore": {
-          "version": "5.1.9",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
           "dev": true
         }
       }
@@ -11187,9 +11359,9 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "jest": "^27.4.5",
         "jest-runner-eslint": "^1.0.0",
         "lint-staged": "^12.1.2",
-        "prettier": "^2.5.1"
+        "prettier": "^2.5.1",
+        "typescript": "^4.7.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6491,7 +6492,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11691,8 +11691,7 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "underscore": {
       "version": "1.13.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "jest": "^27.4.5",
     "jest-runner-eslint": "^1.0.0",
     "lint-staged": "^12.1.2",
-    "prettier": "^2.5.1"
+    "prettier": "^2.5.1",
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-promise",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Enforce best practices for JavaScript promises",
   "keywords": [
     "eslint",
@@ -24,6 +24,7 @@
     "test": "jest --coverage"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^5.35.1",
     "doctoc": "^2.1.0",
     "eslint": "^8.5.0",
     "eslint-config-prettier": "^8.3.0",

--- a/rules/no-native.js
+++ b/rules/no-native.js
@@ -47,7 +47,7 @@ module.exports = {
         const scope = context.getScope()
         const leftToBeResolved =
           scope.implicit.left ||
-          /* istanbul ignore next
+          /**
            * Fixes https://github.com/xjamundx/eslint-plugin-promise/issues/205.
            * The problem was that @typescript-eslint has a scope manager
            * which has `leftToBeResolved` instead of the default `left`.


### PR DESCRIPTION
**What is the purpose of this pull request?**

- Other: added tests for `@typescript-eslint/parser` in the `no-native` rule

**What changes did you make? (Give an overview)**

1. Installed `typescript` and `@typescript-eslint/parser` as a dev dependency.
2. Removed the `istanbul ignore next` directive in the `no-native` source file.
3. Configured a second rule tester with `@typescript-eslint/parser` in the `no-native` test file.
4. Ran both the original rule tester and the TypeScript rule tester in the test file.
5. Bumped the version number from `6.0.0` to `6.0.1` in `package.json` and `package-lock.json`.
